### PR TITLE
Refactor chart display to sidebar cards

### DIFF
--- a/workbench/_web/src/app/workbench/[workspaceId]/lens/components/ChartCardsSidebar.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/lens/components/ChartCardsSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { getOrCreateLensCharts } from "@/lib/queries/chartQueries";
+import { getLensCharts } from "@/lib/queries/chartQueries";
 import { useParams } from "next/navigation";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -14,16 +14,10 @@ export default function ChartCardsSidebar() {
     const { workspaceId } = useParams();
     const { activeTab, setActiveTab, selectedModel } = useWorkspace();
 
-    const { data: { lensCharts, unlinkedCharts } = { lensCharts: [], unlinkedCharts: [] }, isLoading } = useQuery({
+    const { data: lensCharts, isLoading } = useQuery({
         queryKey: ["lensCharts", workspaceId],
-        queryFn: () => getOrCreateLensCharts(workspaceId as string, {
-            workspaceId: workspaceId as string,
-        }),
+        queryFn: () => getLensCharts(workspaceId as string),
     });
-
-    const allCharts = useMemo(() => {
-        return [...(lensCharts || []), ...(unlinkedCharts || [])];
-    }, [lensCharts, unlinkedCharts]);
 
     const { mutate: createPair, isPending: isCreating } = useCreateLensChartPair();
 
@@ -38,6 +32,8 @@ export default function ChartCardsSidebar() {
         });
     };
 
+    if (!lensCharts) return null;
+
     return (
         <div className="flex h-full flex-col overflow-hidden">
             <div className="h-12 px-3 py-2 border-b flex items-center justify-between">
@@ -50,10 +46,10 @@ export default function ChartCardsSidebar() {
                 {isLoading && (
                     <div className="text-xs text-muted-foreground px-2 py-6 text-center">Loading charts…</div>
                 )}
-                {allCharts.length === 0 && !isLoading && (
+                {lensCharts.length === 0 && !isLoading && (
                     <div className="text-xs text-muted-foreground px-2 py-6 text-center">No charts yet. Create one to get started.</div>
                 )}
-                {allCharts.map((chart) => {
+                {lensCharts.map((chart) => {
                     const isSelected = chart.id === activeTab;
                     const type = chart.type as "line" | "heatmap" | null | undefined;
                     const createdAt = chart.createdAt ? new Date(chart.createdAt).toLocaleString() : "";

--- a/workbench/_web/src/app/workbench/[workspaceId]/lens/components/CompletionCard.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/lens/components/CompletionCard.tsx
@@ -18,13 +18,13 @@ import { useLensCharts } from "@/hooks/useLensCharts";
 import { cn } from "@/lib/utils";
 import { useLensWorkspace } from "@/stores/useLensWorkspace";
 
+import { LensConfig } from "@/db/schema";
+
 interface CompletionCardProps {
-    config: LensConfigData;
-    setConfig: (config: LensConfigData) => void;
-    configId: string;
+    initialConfig: LensConfig;
 }
 
-export function CompletionCard({ config, setConfig, configId }: CompletionCardProps) {
+export function CompletionCard({ initialConfig }: CompletionCardProps) {
     const { workspaceId } = useParams<{ workspaceId: string }>();
     const { tokenData, setTokenData } = useLensWorkspace();
 
@@ -36,6 +36,11 @@ export function CompletionCard({ config, setConfig, configId }: CompletionCardPr
 
     const { mutateAsync: getExecuteSelected, isPending: isExecuting } = useExecuteSelected();
     const { mutateAsync: updateChartConfigMutation } = useUpdateChartConfig();
+
+
+    const [config, setConfig] = useState<LensConfigData>(initialConfig.data);
+    const configId = initialConfig.id;
+
     const { handleCreateLineChart, handleCreateHeatmap } = useLensCharts({ config, configId });
 
 
@@ -75,6 +80,7 @@ export function CompletionCard({ config, setConfig, configId }: CompletionCardPr
 
         // Run predictions
         await runPredictions(temporaryConfig);
+        await handleCreateHeatmap();
     }
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/workbench/_web/src/app/workbench/[workspaceId]/lens/components/InteractiveDisplay.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/lens/components/InteractiveDisplay.tsx
@@ -1,56 +1,20 @@
-import { useEffect, useState } from "react";
-import LensTransformer, { type SelectedComponent } from "@/components/transformer/InteractiveTransformer";
-import { LensConfigData } from "@/types/lens";
 import { ModelSelector } from "@/components/ModelSelector";
 import { useWorkspace } from "@/stores/useWorkspace";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { CompletionCard } from "./CompletionCard";
-import { ChevronDown, ChevronRight } from "lucide-react";
-import { useLensWorkspace } from "@/stores/useLensWorkspace";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { getOrCreateLensConfigForChart } from "@/lib/queries/chartQueries";
+import { getConfigForChart } from "@/lib/queries/chartQueries";
 
 export default function InteractiveDisplay() {
     const { selectedModel, activeTab } = useWorkspace();
     const { workspaceId } = useParams<{ workspaceId: string }>();
 
-    const { tokenData } = useLensWorkspace();
-    const [isExpanded, setIsExpanded] = useState(false);
-    const [clickedComponent, setClickedComponent] = useState<SelectedComponent | null>(null);
-
-    const defaultConfig: LensConfigData = {
-        prompt: "",
-        model: selectedModel?.name || "",
-        token: { idx: 0, id: 0, text: "", targetIds: [] },
-    };
-
-    const { data: configRecord, isSuccess } = useQuery({
+    const { data: config } = useQuery({
         queryKey: ["chartConfig", workspaceId, activeTab],
-        queryFn: () => getOrCreateLensConfigForChart(workspaceId as string, activeTab as string, defaultConfig),
+        queryFn: () => getConfigForChart(activeTab as string),
         enabled: !!selectedModel && !!activeTab,
-        staleTime: 0,
+        staleTime: 0, // WHAT DOES THIS DO?
     });
-
-    const [config, setConfig] = useState<LensConfigData | null>(null);
-
-    useEffect(() => {
-        if (isSuccess && configRecord) {
-            setConfig(configRecord.data);
-        } else if (!activeTab) {
-            setConfig(null);
-        }
-    }, [isSuccess, configRecord, activeTab]);
-
-    // Two-knob slider state
-    const getSliderValues = (): [number, number] => {
-        if (!selectedModel) {
-            return [0, 0];
-        }
-        return [0, selectedModel.n_layers - 1];
-    };
-
-    const [sliderValues, setSliderValues] = useState<[number, number]>(getSliderValues());
 
     if (!activeTab) {
         return (
@@ -60,7 +24,7 @@ export default function InteractiveDisplay() {
         );
     }
 
-    if (!config || !configRecord) {
+    if (!config) {
         return (
             <div className="h-full flex items-center justify-center text-muted-foreground">
                 Loading config…
@@ -76,42 +40,7 @@ export default function InteractiveDisplay() {
             </div>
 
             <div className="p-2">
-                <CompletionCard config={config} setConfig={setConfig} configId={configRecord.id} />
-            </div>
-
-            <div className="px-2 pb-2 h-full overflow-auto flex flex-col">
-                {!isExpanded ? (
-                    <button
-                        onClick={() => setIsExpanded(true)}
-                        className="flex items-center gap-2 p-4 border rounded hover:bg-muted/50 transition-colors w-full text-left"
-                    >
-                        <ChevronRight className="h-4 w-4" />
-                        <span className="text-sm font-medium">View Internals</span>
-                    </button>
-                ) : (
-                    <>
-                        <div className="flex gap-2 p-4 justify-between border-t border-x rounded-t">
-                            <button
-                                onClick={() => setIsExpanded(false)}
-                                className="p-1 hover:bg-muted rounded transition-colors"
-                            >
-                                <ChevronDown className="h-4 w-4" />
-                            </button>
-                        </div>
-                        <ScrollArea className="h-full w-full pt-4 flex rounded-b items-center justify-center border">
-                            <LensTransformer
-                                clickedComponent={clickedComponent}
-                                setClickedComponent={setClickedComponent}
-                                rowMode={false}
-                                numTokens={tokenData.length}
-                                layerRange={sliderValues}
-                                scale={0.5}
-                                showFlowOnHover={true}
-                                tokenLabels={tokenData.map((token) => token.text)}
-                            />
-                        </ScrollArea>
-                    </>
-                )}
+                <CompletionCard initialConfig={config} />
             </div>
         </div>
     );

--- a/workbench/_web/src/app/workbench/[workspaceId]/lens/page.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/lens/page.tsx
@@ -17,9 +17,7 @@ import { AnnotationsDisplay } from "../components/AnnotationsDisplay";
 import { ToolTabs } from "../components/ToolTabs";
 import ChartCardsSidebar from "./components/ChartCardsSidebar";
 
-export default function Workbench({ params }: { params: Promise<{ workspaceId: string }> }) {
-    const resolvedParams = use(params);
-
+export default function Workbench() {
     const { annotationsOpen } = useWorkspace();
 
     // Ensure a selected model exists

--- a/workbench/_web/src/components/charts/ChartDisplay.tsx
+++ b/workbench/_web/src/components/charts/ChartDisplay.tsx
@@ -1,6 +1,6 @@
 import { useWorkspace } from "@/stores/useWorkspace";
 import { Loader2, PanelRight, PanelRightClose } from "lucide-react";
-import { getOrCreateLensCharts } from "@/lib/queries/chartQueries";
+import { getLensCharts } from "@/lib/queries/chartQueries";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "next/navigation";
 import { useEffect, useMemo, useRef } from "react";
@@ -14,29 +14,23 @@ export function ChartDisplay() {
     const { activeTab, setActiveTab, setAnnotationsOpen, annotationsOpen } = useWorkspace();
     const { workspaceId } = useParams();
 
-    const { data: { lensCharts, unlinkedCharts } = { lensCharts: [], unlinkedCharts: [] }, isLoading, isSuccess } = useQuery({
+    const { data: lensCharts, isLoading, isSuccess } = useQuery({
         queryKey: ["lensCharts", workspaceId],
-        queryFn: () => getOrCreateLensCharts(workspaceId as string, {
-            workspaceId: workspaceId as string,
-        }),
+        queryFn: () => getLensCharts(workspaceId as string),
     });
 
-    const allCharts = useMemo(() => {
-        return [...(lensCharts || []), ...(unlinkedCharts || [])];
-    }, [lensCharts, unlinkedCharts]);
-
     const activeChart = useMemo(() => {
-        return allCharts?.find(c => c.id === activeTab) || null;
-    }, [allCharts, activeTab]);
+        return lensCharts?.find(c => c.id === activeTab) || null;
+    }, [lensCharts, activeTab]);
 
     // On load, set to the first chart
     const initial = useRef(true);
     useEffect(() => {
-        if (isSuccess && initial.current && allCharts.length > 0) {
-            setActiveTab(allCharts[0].id);
+        if (isSuccess && initial.current && lensCharts.length > 0) {
+            setActiveTab(lensCharts[0].id);
             initial.current = false;
         }
-    }, [isSuccess, allCharts, setActiveTab]);
+    }, [isSuccess, lensCharts, setActiveTab]);
 
     if (isLoading) return (
         <div className="flex-1 flex h-full items-center justify-center">

--- a/workbench/_web/src/lib/api/chartApi.ts
+++ b/workbench/_web/src/lib/api/chartApi.ts
@@ -31,7 +31,7 @@ export const useLensLine = () => {
     return useMutation({
         mutationFn: async ({lensRequest, configId}: { lensRequest: { completion: LensConfigData; chartId: string }; configId: string }) => {
             const response = await getLensLine(lensRequest);
-            await setChartData(lensRequest.chartId, configId, response.data, "line");
+            await setChartData(lensRequest.chartId, response.data, "line");
             return response.data;
         },
         onSuccess: (data, variables) => {
@@ -77,7 +77,7 @@ export const useLensGrid = () => {
     return useMutation({
         mutationFn: async ({ lensRequest, configId }: { lensRequest: {completion: LensConfigData; chartId: string}; configId: string }) => {
             const response = await getLensGrid(lensRequest);
-            await setChartData(lensRequest.chartId, configId, response.data, "heatmap");
+            await setChartData(lensRequest.chartId, response.data, "heatmap");
             return response.data;
         },
         onSuccess: (data, variables) => {
@@ -139,6 +139,7 @@ export const useCreateLensChartPair = () => {
             // Refresh charts and configs
             queryClient.invalidateQueries({ queryKey: ["lensCharts"] });
             queryClient.invalidateQueries({ queryKey: ["unlinkedCharts"] });
+            queryClient.invalidateQueries({ queryKey: ["chartConfig"] });
             // Set active to the new chart id
             setActiveTab(chart.id);
         },


### PR DESCRIPTION
Refactor the chart display to a card-based sidebar to enforce a 1:1 chart-config relationship and improve workspace organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1a9edb5-ab1d-4ecb-a609-fbf30722d9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e1a9edb5-ab1d-4ecb-a609-fbf30722d9e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

