### PR TITLE
ci(preview): recover from interrupted helm operations

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -216,6 +216,59 @@ jobs:
             --from-literal=HF_TOKEN="$HF_TOKEN" \
             --dry-run=client -o yaml | kubectl apply -f -
 
+      # When a prior run gets killed mid-flight (runner OOMKilled,
+      # workflow cancelled, ctrl-c'd before helm finished), the helm
+      # release is left in `pending-upgrade` / `pending-install` /
+      # `pending-rollback`. Every subsequent `helm upgrade --install`
+      # then fails with:
+      #   Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
+      # `--atomic` on the upgrade below handles the case where THIS run
+      # fails (rollback happens before the step exits), but it can't
+      # help when the process is killed externally — no time to clean
+      # up. Detect the leftover pending state and recover here.
+      - name: Recover stuck helm release
+        env:
+          PR_NUM: ${{ steps.meta.outputs.preview_id }}
+          NS: ${{ steps.meta.outputs.namespace }}
+        run: |
+          set -euo pipefail
+          release="pr-${PR_NUM}"
+
+          if ! helm -n "$NS" status "$release" >/dev/null 2>&1; then
+            echo "No existing release $release; nothing to recover."
+            exit 0
+          fi
+
+          status=$(helm -n "$NS" status "$release" -o json \
+            | python3 -c 'import sys, json; print(json.load(sys.stdin).get("info", {}).get("status", ""))')
+          echo "Current release status: $status"
+
+          case "$status" in
+            pending-upgrade|pending-rollback)
+              # Roll forward to the last successful revision. `helm
+              # rollback` writes a new revision mirroring the target,
+              # which clears the pending state.
+              last_deployed=$(helm -n "$NS" history "$release" -o json \
+                | python3 -c 'import sys, json; r=[x["revision"] for x in json.load(sys.stdin) if x["status"]=="deployed"]; print(r[-1] if r else "")')
+              if [ -z "$last_deployed" ]; then
+                echo "::warning::release in $status with no deployed revision in history — uninstalling"
+                helm -n "$NS" uninstall "$release" --wait --timeout 5m
+              else
+                echo "::warning::release in $status — rolling back to revision $last_deployed"
+                helm -n "$NS" rollback "$release" "$last_deployed" --wait --timeout 5m
+              fi
+              ;;
+            pending-install)
+              # First install never completed; no prior good state.
+              # Uninstall so the next upgrade --install starts clean.
+              echo "::warning::release in pending-install — uninstalling"
+              helm -n "$NS" uninstall "$release" --wait --timeout 5m
+              ;;
+            *)
+              echo "Release status OK; no recovery needed."
+              ;;
+          esac
+
       - name: Helm upgrade --install
         env:
           PR_NUM: ${{ steps.meta.outputs.preview_id }}
@@ -225,6 +278,13 @@ jobs:
           API_HOST: ${{ steps.meta.outputs.api_host }}
           TAG: ${{ steps.meta.outputs.tag }}
         run: |
+          # --atomic: if the upgrade fails before --timeout, helm rolls
+          #   back to the prior revision in the same shell invocation,
+          #   leaving the release in `deployed` (not `failed`) state so
+          #   the next run isn't wedged.
+          # --cleanup-on-fail: also deletes any new resources the failed
+          #   upgrade created (implied by --atomic, set explicitly for
+          #   clarity).
           helm upgrade --install "pr-${PR_NUM}" deploy/preview \
             --namespace "$NS" \
             --set image.repository="${IMAGE_NAME}" \
@@ -237,6 +297,7 @@ jobs:
             --set ingress.host="${HOST}" \
             --set ingress.className="${INGRESS_CLASS}" \
             --set ingress.clusterIssuer="${CLUSTER_ISSUER}" \
+            --atomic --cleanup-on-fail \
             --wait --timeout 10m
 
       - name: Write job summary


### PR DESCRIPTION
## Summary

- **Problem.** When the preview-deploy runner is killed mid-`helm upgrade --install` (OOMKilled, workflow cancelled, ctrl-c'd before helm finished), the release is left in `pending-upgrade` / `pending-install` state. Every subsequent run then fails with `Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress` and the only fix is a manual `helm rollback` against the cluster. This wedged PR #114 from 2026-06-23 03:10 UTC until just now.
- **Fix.** Add a recovery step before `helm upgrade --install` that detects `pending-*` state and either rolls back to the last `deployed` revision (clearing the pending state) or uninstalls when there is no prior good state.
- **Defense in depth.** Also add `--atomic --cleanup-on-fail` to the upgrade itself, so future *self-induced* failures roll back in-shell instead of leaving the release stuck. `--atomic` can't help when the runner is killed externally — the recovery step is the safety net for that.

## Test plan

- [x] Reproduced the wedge: PR #114's release (`pr-114` in `workbench-preview-pr-114`) was stuck in `pending-upgrade` at revision 8 (Jun 23 03:10 UTC). Recovered manually with `helm rollback pr-114 7`; the previously-failed run [28068064603](https://github.com/ndif-team/workbench/actions/runs/28068064603) succeeded on rerun (release now at revision 10, deployed).
- [ ] Next push to a preview PR exercises the recovery step's "no recovery needed" branch.
- [ ] Cancel a deploy mid-flight (or kill the runner) and confirm the next push auto-recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved preview deployment reliability with automatic recovery for interrupted deployments stuck in pending states.
  * Enhanced deployment robustness through atomic operations and automatic cleanup on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->