### PR TITLE
ci(preview): move build cache from GHA cache to GHCR

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -146,6 +146,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Build cache lives in GHCR (registry-backed) rather than the GHA
+      # cache service. Why: GHA cache is capped at 10 GiB per repo, and
+      # `mode=max` here pushes the full multi-layer cache (~1.5 GiB per
+      # build) every preview run. We were filling the cap within a week
+      # of activity, which then started failing every new preview with
+      # `error writing layer blob: failed to reserve cache`. GHCR has no
+      # such cap and we already authenticate to it for image pushes.
       - name: Build & push web image
         uses: docker/build-push-action@v6
         with:
@@ -157,8 +164,8 @@ jobs:
             ${{ env.IMAGE_NAME }}:pr-${{ steps.meta.outputs.preview_id }}
           build-args: |
             NEXT_PUBLIC_BACKEND_URL=https://${{ steps.meta.outputs.api_host }}
-          cache-from: type=gha,scope=preview-web
-          cache-to: type=gha,mode=max,scope=preview-web
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Build & push api image
         uses: docker/build-push-action@v6
@@ -169,8 +176,8 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME_API }}:${{ steps.meta.outputs.tag }}
             ${{ env.IMAGE_NAME_API }}:pr-${{ steps.meta.outputs.preview_id }}
-          cache-from: type=gha,scope=preview-api
-          cache-to: type=gha,mode=max,scope=preview-api
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME_API }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME_API }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Set up kubectl & helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
## Summary

- **Problem.** Every preview deploy uses `cache-to: type=gha,mode=max,scope=preview-{web,api}`, which pushes the full multi-layer buildkit cache (~1.5 GiB per build) into [GitHub Actions Cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows). GHA cache is capped at **10 GiB per repo** and only evicts on incoming reservations — but the reservation itself is what fails when full. After ~a week of preview activity, this repo hit 10.56 GiB across 137 entries and every new preview started failing the build step with:
  ```
  exporting to GitHub Actions Cache
  ERROR: error writing layer blob: failed to reserve cache
  ```
  That's what wedged [run #28462108112](https://github.com/ndif-team/workbench/actions/runs/28462108112) on PR #120.
- **Fix.** Switch `cache-from` / `cache-to` from `type=gha` to `type=registry` pointing at GHCR (`ghcr.io/ndif-team/workbench/{web,api}:buildcache`). GHCR has no per-repo cap, we already authenticate to it for the image push, and `mode=max` stays — so cold-build speed on the first run after this merges is the only one-time cost. Subsequent builds pull the cache from GHCR over the same path as the base image.
- **Side benefit.** The cache becomes globally available to any runner (not just the one that wrote it) and survives across runner restarts. With `pull_request_target`, fork PRs use the base repo's token to push the build, so they also write to and read from the same cache scope — same security profile as the existing image pushes.

## Test plan

- [x] Pruned 68 stale entries from GHA cache (~5.7 GiB unused 2+ days) to unstick PR #120's current rerun while this PR is in review. Cache count dropped 137 → 59, headroom restored. (Manual; not part of this PR.)
- [ ] First build after merge will be a cold build (no cache hit on `buildcache` tag yet) — expect ~2× normal duration. Subsequent builds should hit the registry cache and be at or below GHA-cache build times.
- [ ] After the first successful build, verify the `web:buildcache` and `api:buildcache` tags are present in `https://github.com/orgs/ndif-team/packages?repo_name=workbench`.
- [ ] Confirm a follow-up preview build pulls layers via `importing cache manifest from <ref>` (visible in the buildx log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)