### PR TITLE
ci(preview): use shared *.ndif-preview wildcard TLS cert

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -43,7 +43,6 @@ env:
   PREVIEW_DOMAIN: ${{ vars.PREVIEW_DOMAIN }}         # e.g. ndif-preview.ripley.cloud
   PREVIEW_NAMESPACE_PREFIX: ${{ vars.PREVIEW_NAMESPACE_PREFIX || 'workbench-preview' }}
   INGRESS_CLASS: ${{ vars.PREVIEW_INGRESS_CLASS || 'nginx' }}
-  CLUSTER_ISSUER: ${{ vars.PREVIEW_CLUSTER_ISSUER || 'letsencrypt-prod' }}
   # In-cluster ARC runners use a glibc image; some JS actions still ship
   # Node 20 binaries that won't load. Force them to Node 24.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -125,7 +124,10 @@ jobs:
             echo "sha=${sha}"
             echo "tag=pr-${{ steps.pre.outputs.preview_id }}-${sha}"
             echo "host=pr-${{ steps.pre.outputs.preview_id }}.${PREVIEW_DOMAIN}"
-            echo "api_host=api.pr-${{ steps.pre.outputs.preview_id }}.${PREVIEW_DOMAIN}"
+            # Sibling subdomain of `host`, not a child — so one
+            # `*.${PREVIEW_DOMAIN}` wildcard TLS cert covers both. (DNS
+            # wildcards only span one label.)
+            echo "api_host=pr-${{ steps.pre.outputs.preview_id }}-api.${PREVIEW_DOMAIN}"
             echo "namespace=${PREVIEW_NAMESPACE_PREFIX}-pr-${{ steps.pre.outputs.preview_id }}"
           } | tee -a "$GITHUB_OUTPUT"
 
@@ -303,7 +305,6 @@ jobs:
             --set commitSha="${SHA}" \
             --set ingress.host="${HOST}" \
             --set ingress.className="${INGRESS_CLASS}" \
-            --set ingress.clusterIssuer="${CLUSTER_ISSUER}" \
             --atomic --cleanup-on-fail \
             --wait --timeout 10m
 

--- a/deploy/preview/templates/ingress-api.yaml
+++ b/deploy/preview/templates/ingress-api.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "preview.api.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | quote }}
     {{- if .Values.ingress.authGate.enabled }}
     # Same forward-auth gate as the web ingress — relies on the shared
     # cookie domain (.ndif-preview.ripley.cloud) so a single login covers
@@ -32,7 +31,11 @@ spec:
   tls:
     - hosts:
         - {{ .Values.api.host | quote }}
-      secretName: {{ include "preview.api.name" . }}-tls
+      # Same wildcard secret as the web ingress — works because the api
+      # host is a sibling subdomain of the app host (pr-N-api.<domain>
+      # instead of api.pr-N.<domain>), so *.ndif-preview.ripley.cloud
+      # covers both.
+      secretName: {{ .Values.ingress.tlsSecretName }}
   rules:
     - host: {{ .Values.api.host | quote }}
       http:

--- a/deploy/preview/templates/ingress.yaml
+++ b/deploy/preview/templates/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     {{- include "preview.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | quote }}
     {{- if .Values.ingress.authGate.enabled }}
     # Forward-auth via oauth2-proxy (ndif-team org-gated). See
     # k8s/apps/workbench-preview-auth/ in the cluster repo.
@@ -25,7 +24,11 @@ spec:
   tls:
     - hosts:
         - {{ .Values.ingress.host | quote }}
-      secretName: {{ include "preview.name" . }}-tls
+      # Shared *.ndif-preview.ripley.cloud wildcard, mirrored into every
+      # workbench-preview-pr-* namespace by emberstack/reflector. See
+      # k8s/apps/workbench-preview-auth/wildcard-certificate.yaml in the
+      # cluster repo.
+      secretName: {{ .Values.ingress.tlsSecretName }}
   rules:
     - host: {{ .Values.ingress.host | quote }}
       http:

--- a/deploy/preview/values.yaml
+++ b/deploy/preview/values.yaml
@@ -18,7 +18,14 @@ ingress:
   enabled: true
   className: nginx
   host: ""                       # set by workflow, e.g. pr-123.ndif-preview.ripley.cloud
-  clusterIssuer: letsencrypt-prod  # cert-manager ClusterIssuer (DNS-01 on ripley.cloud)
+  # Shared wildcard TLS Secret mirrored into every workbench-preview-pr-*
+  # namespace by emberstack/reflector. The source Certificate
+  # (*.ndif-preview.ripley.cloud) lives in the cert-manager namespace —
+  # see k8s/apps/workbench-preview-auth/wildcard-certificate.yaml in the
+  # cluster repo. Using a shared cert avoids burning through the Let's
+  # Encrypt 50-certs/week/registered-domain quota on per-PR per-host
+  # issuance.
+  tlsSecretName: workbench-preview-wildcard-tls
   annotations: {}
   # Forward-auth gate via oauth2-proxy (GitHub OAuth, ndif-team org-only).
   # See k8s/apps/workbench-preview-auth/ in the cluster repo. Set
@@ -42,8 +49,10 @@ imagePullSecret: ghcr-pull
 env: []
 
 # FastAPI backend (workbench/_api) deployed alongside the Next.js frontend.
-# Reachable at api.<ingress.host>, baked into the web build at
-# NEXT_PUBLIC_BACKEND_URL. Shares the same oauth2-proxy auth gate.
+# Reachable at a SIBLING subdomain of the web host (e.g. pr-123-api.<root>
+# alongside pr-123.<root>) so a single *.<root> wildcard cert covers both.
+# Baked into the web build at NEXT_PUBLIC_BACKEND_URL. Shares the same
+# oauth2-proxy auth gate.
 api:
   enabled: true
   image:
@@ -53,7 +62,7 @@ api:
   service:
     port: 80
     targetPort: 8000
-  host: ""                        # set by workflow, e.g. api.pr-123.ndif-preview.ripley.cloud
+  host: ""                        # set by workflow, e.g. pr-123-api.ndif-preview.ripley.cloud
   replicaCount: 1
   resources:
     requests: { cpu: 200m, memory: 1Gi }


### PR DESCRIPTION
## Summary

- **Problem.** The preview chart annotated each PR's Ingress with `cert-manager.io/cluster-issuer`, so cert-manager auto-issued **two fresh Let's Encrypt certs per PR** (one for `pr-N.ndif-preview.ripley.cloud`, one for `api.pr-N.ndif-preview.ripley.cloud`). Let's Encrypt enforces a **50-certs/week-per-registered-domain** rate limit, and \`ripley.cloud\` is a single registered domain shared across every cluster subdomain — preview activity alone can blow the budget on busy weeks.
- **Fix.** Issue one shared wildcard for \`*.ndif-preview.ripley.cloud\` in the \`cert-manager\` namespace and use emberstack/reflector to mirror the Secret into every \`workbench-preview-pr-*\` namespace. The preview ingresses now reference this mirrored Secret by name and never ask cert-manager for their own cert.
- **API host flattened.** A DNS wildcard only covers one label, so the API host changes from \`api.pr-N.ndif-preview.ripley.cloud\` → \`pr-N-api.ndif-preview.ripley.cloud\` (sibling subdomain of \`pr-N.…\` rather than child). \`NEXT_PUBLIC_BACKEND_URL\` already flows from the workflow into the web build, so previews pick up the new URL automatically on next deploy.

## Cluster-side prerequisite

This PR depends on a Certificate that lives in the cluster repo, not here:
- File: \`k8s/apps/workbench-preview-auth/wildcard-certificate.yaml\`
- Resource: \`Certificate/workbench-preview-wildcard\` in the \`cert-manager\` namespace
- Mirrors into \`workbench-preview-pr-*\` via reflector annotations

**Don't merge this PR until that Certificate has issued and the mirrored \`workbench-preview-wildcard-tls\` Secret is present in at least one existing preview namespace.** Otherwise the next deploy will reference a non-existent secret. Marked as Draft for that reason.

## Test plan

- [ ] \`workbench-preview-wildcard\` Certificate in \`cert-manager\` ns is \`Ready=True\`.
- [ ] Reflector has copied \`workbench-preview-wildcard-tls\` into existing \`workbench-preview-pr-*\` namespaces.
- [ ] After merging, a preview deploy uses the new API URL (\`pr-N-api.…\`) and serves valid TLS on both \`pr-N\` and \`pr-N-api\` hosts.
- [ ] Subsequent PRs do **not** create new \`Certificate\` objects in their preview namespace.

## Cleanup

The orphaned per-host \`Certificate\` objects in existing preview namespaces (\`pr-N-tls\`, \`pr-N-api-tls\`) will keep renewing themselves at 60 days unless we manually delete them. Safe to leave alone (they're not referenced by anything once this PR ships); we can sweep them in a one-time \`kubectl delete cert\` pass after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)