### PR TITLE
Patch Lens: rewrite source box to trimmed prompt on run (+ E2E)

### DIFF
--- a/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
@@ -332,6 +332,12 @@ export default function PatchLensArea({
         // token and collapses the model's prediction onto whitespace/digits.
         const src = sourcePrompt.trim();
         const tgt = targetPrompt.trim();
+        // Reflect the trimmed text back into the editors so the textbox matches
+        // what was actually run (and the heatmap): otherwise sourcePrompt still
+        // holds the trailing space while lastRun snapshots the trimmed prompt,
+        // and the prompt-vs-heatmap mismatch hides the prediction hint.
+        if (src !== sourcePrompt) onSourcePromptChange(src);
+        if (tgt !== targetPrompt) onTargetPromptChange(tgt);
 
         if (!chartId) {
             toast.error("Missing chart id.");
@@ -357,6 +363,8 @@ export default function PatchLensArea({
         selectedModel,
         sourcePrompt,
         targetPrompt,
+        onSourcePromptChange,
+        onTargetPromptChange,
         runLogitLens,
         onLensResult,
         chartId,

--- a/workbench/_web/tests/patch-lens-trim.spec.ts
+++ b/workbench/_web/tests/patch-lens-trim.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import { waitForModelsLoaded, REAL_NDIF_TIMEOUT_MS } from "./fixtures";
+
+/**
+ * Regression E2E for the patch-lens prompt-trim behavior.
+ *
+ * A trailing space in the source prompt tokenizes as its own token and
+ * collapses the prediction, so Patch Lens trims the prompt before running.
+ * The bug: it sent the trimmed prompt to the model (heatmap computed on the
+ * trimmed text) but left the trailing space in the source box — so the box no
+ * longer matched the heatmap and the predicted-next-token hint was suppressed.
+ *
+ * Correct behavior (asserted here): running rewrites the source box to the
+ * trimmed prompt, so the textbox matches what was actually run.
+ *
+ * Uses the seeded chart (tests/seed-patch-lens.cjs) as a landing point, then
+ * does a real gpt2 run against NDIF (same pattern as logit-lens.spec.ts).
+ */
+
+const WS = "11111111-1111-4111-8111-111111111111";
+const CHART = "22222222-2222-4222-8222-222222222222";
+const URL = `/workbench/${WS}/patch-lens/${CHART}`;
+
+const SOURCE = "#patch-lens-source-prompt";
+const PROMPT_WITH_SPACE = "The Eiffel Tower is in the city of ";
+const PROMPT_TRIMMED = "The Eiffel Tower is in the city of";
+
+// The seeded source composer opens in the tokenized chip view; click it to
+// reveal the textarea, then return the textarea locator.
+async function openSourceEditor(page: Page) {
+    const section = page.locator(SOURCE);
+    const textarea = section.getByPlaceholder(/Enter source prompt/i);
+    if ((await textarea.count()) === 0) {
+        await section.click();
+    }
+    return textarea;
+}
+
+test.describe("patch-lens prompt trimming (real NDIF)", () => {
+    // Real NDIF jobs can take a while to start, run, and round-trip.
+    test.setTimeout(REAL_NDIF_TIMEOUT_MS * 4);
+
+    test.beforeAll(() => {
+        execFileSync("node", ["tests/seed-patch-lens.cjs"], { stdio: "inherit" });
+    });
+
+    test.beforeEach(async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 900 });
+        // Keep the auto-starting tutorial closed so it doesn't overlay the controls.
+        await page.addInitScript(() =>
+            localStorage.setItem("workbench:patch-lens-tutorial-completed:v1", "true"),
+        );
+        await page.goto(URL);
+    });
+
+    test("running a trailing-space prompt rewrites the source box to the trimmed text", async ({
+        page,
+    }) => {
+        await waitForModelsLoaded(page); // pick gpt2 — small + always deployed
+
+        // Enter a source prompt WITH a trailing space.
+        const textarea = await openSourceEditor(page);
+        await expect(textarea).toBeVisible({ timeout: 15_000 });
+        await textarea.fill(PROMPT_WITH_SPACE);
+        await expect(textarea).toHaveValue(PROMPT_WITH_SPACE);
+
+        // Run against NDIF.
+        await page.getByRole("button", { name: /Run Patch Lens/i }).click();
+        // Wait for the run to finish (the button reverts from "Computing...").
+        await expect(page.getByText(/Computing/i)).toHaveCount(0, {
+            timeout: REAL_NDIF_TIMEOUT_MS,
+        });
+
+        // The fix: the source box now holds the trimmed prompt (no trailing
+        // space), matching the prompt the heatmap was computed from.
+        const reopened = await openSourceEditor(page);
+        await expect(reopened).toHaveValue(PROMPT_TRIMMED);
+    });
+});


### PR DESCRIPTION
## Problem

Patch Lens trims the source/target prompt before running (a trailing space tokenizes as its own token and collapses the prediction). But `handleRun` only trimmed the value it *sent* — it left the trailing space in the source textbox. So after a run:

- heatmap was computed from `"…city of"` (trimmed)
- the source box still held `"…city of "` (with space)
- `lastRunSrcPrompt` (trimmed) ≠ `sourcePrompt` (raw) → the box no longer matched the heatmap, which suppressed the predicted-next-token hint.

## Fix

Reflect the trimmed text back into the editors in `handleRun`:

```ts
const src = sourcePrompt.trim();
const tgt = targetPrompt.trim();
if (src !== sourcePrompt) onSourcePromptChange(src);
if (tgt !== targetPrompt) onTargetPromptChange(tgt);
```

Now the textbox matches what actually ran (and the heatmap).

## Test

`tests/patch-lens-trim.spec.ts` (real NDIF, gpt2, seeded chart as the landing point): enters a source prompt with a trailing space, runs, and asserts the source box is rewritten to the trimmed prompt.

## Verification
`tsc --noEmit`, `eslint`, `prettier --check` clean on changed files; `playwright test --list` collects the new spec. (Full Playwright run happens in CI — the local sandbox can't hold a long-lived web server.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt inputs in Patch Lens are now automatically trimmed before running, and the trimmed values are written back into the editor so what you see matches what was used for the computation.
  * Added end-to-end coverage to prevent regressions in prompt trimming behavior during Patch Lens runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->