### PR TITLE
Patch Lens usability fixes from pilot feedback (+ expanded e2e/visual regression)

### DIFF
--- a/workbench/_web/bun.lock
+++ b/workbench/_web/bun.lock
@@ -35,7 +35,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#29ace9f",
+        "edulogitlens": "github:jon-bell/edulogitlens#38d582a",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",
@@ -1100,7 +1100,7 @@
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
-    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#29ace9f", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-29ace9f", "sha512-SMQztgq6KGvC9zGI13UZxkwk42eA+PpE2Vsr/wT5TAPmJ//+lMqeHSqaBqBOCa3gc7uVz35Er8GZcAbT6uOZBQ=="],
+    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#38d582a", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-38d582a", "sha512-scafsTvOezDAjBsr2HB6GNO3xcHrGmdEz5jjmaX/+BXwECprscg9R8WlvXxJ0i+m7MydbBOEPAyWzIi8spjb+g=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.200", "", {}, "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="],
 

--- a/workbench/_web/bun.lock
+++ b/workbench/_web/bun.lock
@@ -35,7 +35,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#67615a1",
+        "edulogitlens": "github:jon-bell/edulogitlens#61be83a",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",
@@ -1100,7 +1100,7 @@
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
-    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#67615a1", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-67615a1", "sha512-Bky7kEdpWWVZ86JTC8/XPrmDiJFBKEZPihQVPPCouzp50Esay0h+XL2XhBiyem85Weds8mEgdl++EUpQv5iLYA=="],
+    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#61be83a", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-61be83a", "sha512-0H2TKnmko58/cM7DiHnUDgwPj6mq0d4xVdTdpVws+YcDp/K17vv683CqxaxUB7/cAAubo65NLyiub543tubvxA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.200", "", {}, "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="],
 

--- a/workbench/_web/bun.lock
+++ b/workbench/_web/bun.lock
@@ -35,7 +35,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#488b200",
+        "edulogitlens": "github:jon-bell/edulogitlens#29ace9f",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",
@@ -1100,7 +1100,7 @@
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
-    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#488b200", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-488b200", "sha512-CpJ/oE/7/h1xQ7s8ZIQAn+x7Z8PF9Z6v4m4TrPGgy/wjtf8oUmy2zs2ka4o9D8VRF9+D2KH4Owi1WraLKl4lXw=="],
+    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#29ace9f", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-29ace9f", "sha512-SMQztgq6KGvC9zGI13UZxkwk42eA+PpE2Vsr/wT5TAPmJ//+lMqeHSqaBqBOCa3gc7uVz35Er8GZcAbT6uOZBQ=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.200", "", {}, "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="],
 

--- a/workbench/_web/bun.lock
+++ b/workbench/_web/bun.lock
@@ -35,7 +35,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#61be83a",
+        "edulogitlens": "github:jon-bell/edulogitlens#488b200",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",
@@ -1100,7 +1100,7 @@
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
-    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#61be83a", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-61be83a", "sha512-0H2TKnmko58/cM7DiHnUDgwPj6mq0d4xVdTdpVws+YcDp/K17vv683CqxaxUB7/cAAubo65NLyiub543tubvxA=="],
+    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#488b200", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-488b200", "sha512-CpJ/oE/7/h1xQ7s8ZIQAn+x7Z8PF9Z6v4m4TrPGgy/wjtf8oUmy2zs2ka4o9D8VRF9+D2KH4Owi1WraLKl4lXw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.200", "", {}, "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="],
 

--- a/workbench/_web/package.json
+++ b/workbench/_web/package.json
@@ -46,7 +46,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#488b200",
+        "edulogitlens": "github:jon-bell/edulogitlens#29ace9f",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",

--- a/workbench/_web/package.json
+++ b/workbench/_web/package.json
@@ -46,7 +46,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#67615a1",
+        "edulogitlens": "github:jon-bell/edulogitlens#61be83a",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",

--- a/workbench/_web/package.json
+++ b/workbench/_web/package.json
@@ -46,7 +46,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#29ace9f",
+        "edulogitlens": "github:jon-bell/edulogitlens#38d582a",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",

--- a/workbench/_web/package.json
+++ b/workbench/_web/package.json
@@ -46,7 +46,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#61be83a",
+        "edulogitlens": "github:jon-bell/edulogitlens#488b200",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",

--- a/workbench/_web/playwright.config.ts
+++ b/workbench/_web/playwright.config.ts
@@ -3,6 +3,8 @@ import { createArgosReporterOptions } from "@argos-ci/playwright/reporter";
 
 export default defineConfig({
     testDir: "./tests",
+    // Warm gpt2 on NDIF before the real-NDIF specs (no-op when already hot).
+    globalSetup: "./tests/global-setup.ts",
     fullyParallel: true,
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCardsSidebar.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCardsSidebar.tsx
@@ -31,12 +31,13 @@ import {
     Loader2,
     Plus,
     PanelLeftClose,
-    PanelLeft,
+    PanelLeftOpen,
     FileText,
     Layers,
     GitBranch,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import { PatchLensIcon } from "@/components/PatchLensIcon";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -393,7 +394,9 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
     if (isCollapsed && !fillWidth) {
         return (
             <div className="flex h-full flex-col w-10 p-2 pt-0 items-center transition-all duration-300 ease-in-out">
-                {/* Expand button - top */}
+                {/* Expand button - top. Full opacity + a distinct "open" icon and a
+                    separator set it apart from the create-action icons below, which
+                    otherwise look identical and hide the way to reopen the sidebar. */}
                 <Button
                     variant="ghost"
                     size="icon"
@@ -401,11 +404,13 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
                     className="mt-2 h-7 w-7 hover:bg-muted"
                     title="Expand sidebar"
                 >
-                    <PanelLeft className="h-4 w-4" />
+                    <PanelLeftOpen className="h-4 w-4" />
                 </Button>
 
+                <Separator className="my-2 w-6" />
+
                 {/* Action buttons - below expand */}
-                <div className="flex flex-col items-center gap-2 mt-3">
+                <div className="flex flex-col items-center gap-2">
                     <Button
                         variant="ghost"
                         size="icon"
@@ -483,7 +488,7 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
                     variant="ghost"
                     size="icon"
                     onClick={toggleCollapse}
-                    className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 h-6 w-6 rounded-full bg-background/60 hover:bg-background/90 border border-border/50 opacity-40 hover:opacity-100 transition-opacity z-10"
+                    className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/2 h-6 w-6 rounded-full bg-background/60 hover:bg-background/90 border border-border/50 opacity-70 hover:opacity-100 transition-opacity z-10"
                     title="Collapse sidebar"
                 >
                     <PanelLeftClose className="h-3 w-3" />

--- a/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/LensCompareOverlay.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/LensCompareOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
-import { LogitLensGrid } from "edulogitlens";
+import { LogitLensGrid, formatTokenDisplay } from "edulogitlens";
 import {
     Dialog,
     DialogContent,
@@ -187,7 +187,7 @@ function LastRowTable({ model, refs }: { model: string; refs: PromptResultRef[] 
                                                     : "text-foreground/80",
                                             )}
                                         >
-                                            {cell.token.trim() || "·"}
+                                            {formatTokenDisplay(cell.token)}
                                         </span>
                                     </div>
                                 );

--- a/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
@@ -6,6 +6,12 @@ import { useQuery } from "@tanstack/react-query";
 import { AlertCircle, Loader2, Play, X } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useTour } from "@reactour/tour";
 import { PatchLensTutorial } from "@/tutorials/patchLens";
 import { usePatchLensTutorial, hydratePatchLensTutorial } from "@/stores/usePatchLensTutorial";
@@ -67,9 +73,9 @@ function useTutorialAutoStart() {
         return () => clearTimeout(id);
     }, [completed, isOpen, setSteps, setIsOpen, markCompleted]);
 
-    const startTutorial = () => {
+    const startTutorial = (chapterIdx: number = 0) => {
         if (!setSteps || !setIsOpen) return;
-        const steps = PatchLensTutorial.chapters[0]?.steps ?? [];
+        const steps = PatchLensTutorial.chapters[chapterIdx]?.steps ?? [];
         setSteps(steps);
         setIsOpen(true);
     };
@@ -383,14 +389,27 @@ export default function PatchLensArea({
                             </TooltipContent>
                         </Tooltip>
                     )}
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 px-2 text-xs text-muted-foreground"
-                        onClick={startTutorial}
-                    >
-                        Tutorial
-                    </Button>
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 px-2 text-xs text-muted-foreground"
+                            >
+                                Tutorial
+                            </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                            {PatchLensTutorial.chapters.map((chapter, idx) => (
+                                <DropdownMenuItem
+                                    key={chapter.title}
+                                    onSelect={() => startTutorial(idx)}
+                                >
+                                    {chapter.title}
+                                </DropdownMenuItem>
+                            ))}
+                        </DropdownMenuContent>
+                    </DropdownMenu>
                 </div>
             </div>
 

--- a/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
@@ -31,6 +31,12 @@ import { LensHistoryRail } from "./LensHistoryRail";
 // index 0 in the model list is the 70B (80 layers), far too many for a primer.
 const DEFAULT_INTRO_MODEL = "meta-llama/Llama-3.1-8B";
 
+// A known-good source prompt for the tutorial / first-time users. On the
+// default intro model it produces a clear "Paris" prediction, so the lens
+// heatmap reads well. Source only — the "Reading the lens" chapter wants the
+// target left blank, and the patching chapter walks the user through adding it.
+const EXAMPLE_SOURCE = "The Eiffel Tower is in the city of";
+
 interface PatchLensAreaProps {
     sourcePrompt: string;
     targetPrompt: string;
@@ -50,7 +56,7 @@ interface PatchLensAreaProps {
 }
 
 function useTutorialAutoStart() {
-    const { setSteps, setIsOpen, isOpen } = useTour();
+    const { setSteps, setIsOpen, setCurrentStep, isOpen } = useTour();
     const { completed, markCompleted } = usePatchLensTutorial();
     // Auto-start fires at most once per mount; dismissing then resaving the
     // localStorage flag prevents a popup loop (same pattern as lens-intro).
@@ -66,17 +72,24 @@ function useTutorialAutoStart() {
         autoStartedRef.current = true;
         const steps = PatchLensTutorial.chapters[0]?.steps ?? [];
         setSteps(steps);
+        // reactour keeps currentStep at the provider level, so reset to the
+        // start explicitly rather than relying on the (already-0) default.
+        setCurrentStep(0);
         const id = setTimeout(() => {
             setIsOpen(true);
             markCompleted();
         }, 600);
         return () => clearTimeout(id);
-    }, [completed, isOpen, setSteps, setIsOpen, markCompleted]);
+    }, [completed, isOpen, setSteps, setIsOpen, setCurrentStep, markCompleted]);
 
     const startTutorial = (chapterIdx: number = 0) => {
         if (!setSteps || !setIsOpen) return;
         const steps = PatchLensTutorial.chapters[chapterIdx]?.steps ?? [];
         setSteps(steps);
+        // Always restart from step 1. reactour retains the last step index across
+        // opens, so without this a reopen (e.g. after clicking Done on the last
+        // step) resumes at the end instead of the beginning.
+        setCurrentStep(0);
         setIsOpen(true);
     };
 
@@ -297,6 +310,16 @@ export default function PatchLensArea({
         setTimeout(() => tgtTextareaRef.current?.focus(), 0);
     }, [onTargetPromptChange]);
 
+    // Load a known-good example into the source prompt so first-time users (and
+    // the tutorial) have something that works to follow along with. Source only:
+    // the lens chapter wants the target blank. Focusing after the fill lets the
+    // blur-driven tokenization show the token chips.
+    const handleTryExample = useCallback(() => {
+        onSourcePromptChange(EXAMPLE_SOURCE);
+        setSrcEditing(true);
+        setTimeout(() => srcTextareaRef.current?.focus(), 0);
+    }, [onSourcePromptChange]);
+
     // Flag stale tokenization for EITHER prompt: the source or the target may
     // have been tokenized with a model that's no longer selected.
     const configModelUnavailable =
@@ -415,7 +438,7 @@ export default function PatchLensArea({
 
             <div className="p-3 flex-1 overflow-auto flex flex-col gap-4">
                 <div id="patch-lens-source-prompt" className="flex flex-col gap-1.5 relative">
-                    {sourcePrompt && (
+                    {sourcePrompt ? (
                         <button
                             type="button"
                             onClick={handleClearSrc}
@@ -425,6 +448,16 @@ export default function PatchLensArea({
                         >
                             <X className="h-3 w-3" />
                             <span>Clear</span>
+                        </button>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={handleTryExample}
+                            disabled={isRunning}
+                            className="absolute top-0 right-0 text-xs text-muted-foreground hover:text-foreground disabled:opacity-40 h-5 px-1"
+                            title={`Load an example prompt: "${EXAMPLE_SOURCE}"`}
+                        >
+                            Try an example
                         </button>
                     )}
                     <PatchPromptSection

--- a/workbench/_web/src/components/providers/TourProvider.tsx
+++ b/workbench/_web/src/components/providers/TourProvider.tsx
@@ -2,6 +2,8 @@
 
 import { TourProvider as ReactourTourProvider, type PopoverContentProps } from "@reactour/tour";
 import React, { type ReactNode } from "react";
+import { Info } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface TourProviderProps {
     children: ReactNode;
@@ -28,9 +30,26 @@ function ContentComponent({ currentStep, steps, setIsOpen, setCurrentStep }: Pop
                 {renderTextWithBackticks(content as string)}
             </div>
             <div className="flex items-center justify-between gap-2 border-t pt-2">
-                <span className="text-xs text-muted-foreground">
-                    {currentStep + 1} / {steps.length}
-                </span>
+                <div className="flex items-center gap-1.5">
+                    <span className="text-xs text-muted-foreground">
+                        {currentStep + 1} / {steps.length}
+                    </span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                aria-label="How to use this walkthrough"
+                                className="text-muted-foreground hover:text-foreground transition-colors"
+                            >
+                                <Info className="h-3.5 w-3.5" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="max-w-[240px]">
+                            Use Prev / Next to step through. Close with Done or ✕ — you can
+                            reopen this walkthrough anytime from the Tutorial menu.
+                        </TooltipContent>
+                    </Tooltip>
+                </div>
                 <div className="flex items-center gap-2">
                     {!isFirst && (
                         <button

--- a/workbench/_web/src/components/providers/TourProvider.tsx
+++ b/workbench/_web/src/components/providers/TourProvider.tsx
@@ -45,8 +45,8 @@ function ContentComponent({ currentStep, steps, setIsOpen, setCurrentStep }: Pop
                             </button>
                         </TooltipTrigger>
                         <TooltipContent side="top" className="max-w-[240px]">
-                            Use Prev / Next to step through. Close with Done or ✕ — you can
-                            reopen this walkthrough anytime from the Tutorial menu.
+                            Use Prev / Next to step through. Close with Done or ✕ — you can reopen
+                            this walkthrough anytime from the Tutorial menu.
                         </TooltipContent>
                     </Tooltip>
                 </div>

--- a/workbench/_web/src/stores/usePatchLensTutorial.ts
+++ b/workbench/_web/src/stores/usePatchLensTutorial.ts
@@ -1,6 +1,9 @@
 import { create } from "zustand";
 
-const STORAGE_KEY = "workbench:patch-lens-tutorial-completed:v1";
+// v2: the tutorial was split into "Reading the lens" (auto-run) +
+// "Activation patching" (manual); bumping the key re-triggers the auto-run
+// once for users who completed the old single-chapter version.
+const STORAGE_KEY = "workbench:patch-lens-tutorial-completed:v2";
 
 interface PatchLensTutorialState {
     completed: boolean;

--- a/workbench/_web/src/tutorials/patchLens.ts
+++ b/workbench/_web/src/tutorials/patchLens.ts
@@ -1,15 +1,61 @@
 import type { ExtendedStepType, TutorialChapterProgress, TutorialProgress } from "@/types/tutorial";
 
 /**
- * Tutorial for the CM (causal mediation / activation patching) intro feature.
+ * Tutorial for Patch Lens (causal mediation / activation patching intro).
+ *
+ * Two chapters: "Reading the lens" auto-runs on first visit and covers the
+ * logit-lens (single-prompt) side only; "Activation patching" is opened
+ * manually from the Tutorial menu once users are comfortable with the lens.
  *
  * Selector ids must be present in PatchLensArea.tsx and PatchLensDisplay.tsx.
  */
-const PatchLensSteps: ExtendedStepType[] = [
+const ReadingTheLensSteps: ExtendedStepType[] = [
     {
         selector: "#patch-lens-welcome",
         content:
-            "Welcome to activation patching.\n\nThis tool lets you take a piece of internal state from one prompt's forward pass and inject it into another prompt's forward pass at the same layer and position. By watching what changes downstream, you can locate the parts of the model that 'carry' a particular piece of information.",
+            "Welcome to Patch Lens.\n\nPatch Lens is two tools in one. First, it's a logit lens: a per-layer view of what the model is 'thinking' at every position in your prompt. Second, it's an activation-patching tool for moving internal state between prompts.\n\nThis tour covers the logit lens — start here.",
+        styles: {
+            maskArea: (base) => ({ ...base, display: "none" }),
+        },
+    },
+    {
+        selector: "#patch-lens-source-prompt",
+        content:
+            "Enter a Source prompt. Pick something that produces a clear, specific prediction (e.g. 'The Eiffel Tower is in the city of').\n\nLeave Target blank for now — with a single prompt, Patch Lens is a pure logit-lens viewer.",
+    },
+    {
+        selector: "#patch-lens-run",
+        content: "Click Run to compute the logit lens.",
+        trigger: {
+            type: "click",
+            target: "#patch-lens-run",
+        },
+    },
+    {
+        selector: "#patch-lens-display",
+        content:
+            "Reading the heatmap: each row is a token position in your prompt (a ␣ marks a space that is part of a token), and each column is a layer. Each cell shows the model's top guess at that point — darker fill means higher probability.\n\nLarge models get downsampled to fit: amber bands mark hidden rows or columns, and the axis labels show the current step. Click an amber band to expand what it hides.",
+    },
+    {
+        selector: "#patch-lens-display",
+        content:
+            "Click any cell to open its top predictions in the side panel. Labeled borders call out two special rows: this position's final-layer prediction, and the model's final output token.\n\nThe click also draws a crosshair + causal cone on the grid — the 'About this view' legend in the panel explains each region.",
+    },
+    {
+        selector: "#patch-lens-welcome",
+        content:
+            "That's the logit lens. Explore with it FIRST — watch where predictions emerge across layers and get a feel for a few prompts.\n\nWhen you're ready for interventions, open the Tutorial menu above and pick 'Activation patching'.",
+        styles: {
+            maskArea: (base) => ({ ...base, display: "none" }),
+        },
+    },
+];
+
+const ActivationPatchingSteps: ExtendedStepType[] = [
+    {
+        selector: "#patch-lens-welcome",
+        content:
+            "Activation patching takes a piece of internal state from one prompt's forward pass and injects it into another prompt's forward pass at the same layer and position. By watching what changes downstream, you can locate the parts of the model that 'carry' a particular piece of information.",
         styles: {
             maskArea: (base) => ({ ...base, display: "none" }),
         },
@@ -22,7 +68,7 @@ const PatchLensSteps: ExtendedStepType[] = [
     {
         selector: "#patch-lens-target-prompt",
         content:
-            "Add a Target prompt — the prompt whose forward pass you'll PATCH INTO. Typically you pick something with similar grammar but a different answer (e.g. 'The Big Ben is in the city of'), so any change in the target's prediction tells you that the patched activation carried the answer.\n\nYou can leave Target blank to use Patch Lens as a single-prompt lens viewer.",
+            "Add a Target prompt — the prompt whose forward pass you'll PATCH INTO. Typically you pick something with similar grammar but a different answer (e.g. 'The Big Ben is in the city of'), so any change in the target's prediction tells you that the patched activation carried the answer.",
     },
     {
         selector: "#patch-lens-run",
@@ -56,8 +102,13 @@ const PatchLensSteps: ExtendedStepType[] = [
 
 const PatchLensChapters: TutorialChapterProgress[] = [
     {
-        title: "Getting started",
-        steps: PatchLensSteps,
+        title: "Reading the lens",
+        steps: ReadingTheLensSteps,
+        completed: false,
+    },
+    {
+        title: "Activation patching",
+        steps: ActivationPatchingSteps,
         completed: false,
     },
 ];
@@ -66,5 +117,5 @@ export const PatchLensTutorial: TutorialProgress = {
     chapters: PatchLensChapters,
     currentChapter: 0,
     description:
-        "A walkthrough of Patch Lens (causal mediation / activation patching). Learn how to set up source and target prompts, run an intervention by dragging a cell from one heatmap to another, and interpret the resulting changes.",
+        "A walkthrough of Patch Lens. Chapter one covers reading the logit-lens heatmap with a single prompt; chapter two covers running an activation-patching intervention by dragging a cell from one heatmap to another and interpreting the resulting changes.",
 };

--- a/workbench/_web/src/tutorials/patchLens.ts
+++ b/workbench/_web/src/tutorials/patchLens.ts
@@ -21,7 +21,7 @@ const ReadingTheLensSteps: ExtendedStepType[] = [
     {
         selector: "#patch-lens-source-prompt",
         content:
-            "Enter a Source prompt. Pick something that produces a clear, specific prediction (e.g. 'The Eiffel Tower is in the city of').\n\nLeave Target blank for now — with a single prompt, Patch Lens is a pure logit-lens viewer.",
+            "Enter a Source prompt. Click 'Try an example' to load a known-good prompt ('The Eiffel Tower is in the city of'), or type your own — pick something that produces a clear, specific prediction.\n\nLeave Target blank for now — with a single prompt, Patch Lens is a pure logit-lens viewer.",
     },
     {
         selector: "#patch-lens-run",
@@ -63,7 +63,7 @@ const ActivationPatchingSteps: ExtendedStepType[] = [
     {
         selector: "#patch-lens-source-prompt",
         content:
-            "Start with a Source prompt — the prompt whose internal state you want to STEAL from. Pick something that produces a clear, specific prediction (e.g. 'The Eiffel Tower is in the city of').",
+            "Start with a Source prompt — the prompt whose internal state you want to STEAL from. Click 'Try an example' to load 'The Eiffel Tower is in the city of', or type your own prompt that produces a clear, specific prediction.",
     },
     {
         selector: "#patch-lens-target-prompt",

--- a/workbench/_web/src/tutorials/patchLens.ts
+++ b/workbench/_web/src/tutorials/patchLens.ts
@@ -35,11 +35,22 @@ const ReadingTheLensSteps: ExtendedStepType[] = [
         selector: "#patch-lens-display",
         content:
             "Reading the heatmap: each row is a token position in your prompt (a ␣ marks a space that is part of a token), and each column is a layer. Each cell shows the model's top guess at that point — darker fill means higher probability.\n\nLarge models get downsampled to fit: amber bands mark hidden rows or columns, and the axis labels show the current step. Click an amber band to expand what it hides.",
+        // The display mounts asynchronously (skeleton → widget) and grows as cells
+        // animate in; without these reactour would size the highlight against a
+        // missing/half-rendered element. The observers recompute on mount + resize.
+        mutationObservables: ["#patch-lens-display"],
+        resizeObservables: ["#patch-lens-display"],
     },
     {
         selector: "#patch-lens-display",
         content:
             "Click any cell to open its top predictions in the side panel. Labeled borders call out two special rows: this position's final-layer prediction, and the model's final output token.\n\nThe click also draws a crosshair + causal cone on the grid — the 'About this view' legend in the panel explains each region.",
+        // Highlight the grid to invite the click, then expand the mask to the
+        // top-predictions panel the moment it mounts (it renders outside the
+        // display box, and only after a cell is selected).
+        highlightedSelectors: ["#patch-lens-display", "#patch-lens-topk"],
+        mutationObservables: ["#patch-lens-display", "#patch-lens-topk"],
+        resizeObservables: ["#patch-lens-display", "#patch-lens-topk"],
     },
     {
         selector: "#patch-lens-welcome",
@@ -82,21 +93,30 @@ const ActivationPatchingSteps: ExtendedStepType[] = [
         selector: "#patch-lens-display",
         content:
             "You now see two heatmaps, one per prompt. Same axes as the lens: rows are token positions, columns are layers. Click any cell to see a crosshair + the 'About this view' legend in the side panel.",
+        highlightedSelectors: ["#patch-lens-display", "#patch-lens-topk"],
+        mutationObservables: ["#patch-lens-display", "#patch-lens-topk"],
+        resizeObservables: ["#patch-lens-display", "#patch-lens-topk"],
     },
     {
         selector: "#patch-lens-display",
         content:
             "To run an intervention, DRAG a cell from the Source heatmap and DROP it on a cell in the Target heatmap. Workbench will:\n\n  1. Run the Source prompt and capture the residual stream at the cell you dragged.\n  2. Run the Target prompt, but overwrite the residual stream at the drop position with the captured Source value.\n  3. Show you the Target's NEW per-layer predictions in a third heatmap below.",
+        mutationObservables: ["#patch-lens-display"],
+        resizeObservables: ["#patch-lens-display"],
     },
     {
         selector: "#patch-lens-display",
         content:
             "Reading the result heatmap: compare it to the original Target heatmap. Any cell that CHANGED means the patched activation influenced that downstream computation. Cells that stayed the same were unaffected — that part of the network ignored the swap.\n\nThe pattern of changes tells you where in the model the patched information is being read by later layers.",
+        mutationObservables: ["#patch-lens-display"],
+        resizeObservables: ["#patch-lens-display"],
     },
     {
         selector: "#patch-lens-display",
         content:
             "A classic experimental design: pick a Source and Target that differ in ONE controlled way (e.g. 'Paris' vs 'London' as the answer). Then patch one layer at a time. The earliest layer where patching flips the Target's prediction to the Source's answer tells you where that fact is 'stored' in the residual stream.\n\nThis is the basic recipe for causal mediation analysis.",
+        mutationObservables: ["#patch-lens-display"],
+        resizeObservables: ["#patch-lens-display"],
     },
 ];
 

--- a/workbench/_web/tests/global-setup.ts
+++ b/workbench/_web/tests/global-setup.ts
@@ -1,6 +1,12 @@
 /**
- * Playwright global setup: make sure gpt2 is actually deployed on NDIF before
- * the real-NDIF specs run.
+ * Playwright global setup: seed the patch-lens fixtures once, and make sure
+ * gpt2 is actually deployed on NDIF before the real-NDIF specs run.
+ *
+ * Seeding lives here (not in per-describe beforeAll hooks) because the seed
+ * script deletes/reinserts the fixed charts — under fullyParallel workers a
+ * later describe's reseed could reset a chart another worker was mid-test on.
+ * Global setup runs before any worker starts. The one test that MUTATES its
+ * chart (the F1 history restore) re-runs the seed scoped to its own chart.
  *
  * The fixtures pick gpt2 in the header model selector, but since the
  * model-selector redesign the picker hides non-runnable (cold) models — so if
@@ -15,18 +21,28 @@
  * need a backend, and the NDIF specs will fail with their own clear errors.
  */
 
+import { execFileSync } from "node:child_process";
+
 const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000";
 const NDIF = process.env.NEXT_PUBLIC_NDIF_URL || "https://api.ndif.us";
 const MODEL = "openai-community/gpt2";
 
 const JOB_TIMEOUT_MS = 15 * 60_000; // cold deploys are slow
 const CATALOG_TIMEOUT_MS = 3 * 60_000; // backend /status refresh is ~60s
+// Per-request cap so a stalled backend/NDIF socket fails fast instead of
+// hanging setup until the outer CI timeout (the loop deadlines above only
+// advance once a fetch resolves).
+const FETCH_TIMEOUT_MS = 30_000;
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+function fetchWithTimeout(input: string, init: Parameters<typeof fetch>[1] = {}) {
+    return fetch(input, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+}
+
 async function modelStatus(): Promise<string | null> {
     try {
-        const resp = await fetch(`${BACKEND}/models/`, {
+        const resp = await fetchWithTimeout(`${BACKEND}/models/`, {
             headers: { "X-User-Email": "e2e@workbench" },
         });
         if (!resp.ok) return null;
@@ -38,6 +54,11 @@ async function modelStatus(): Promise<string | null> {
 }
 
 export default async function globalSetup() {
+    // Seed the fixed patch-lens charts + history once, before any worker
+    // starts. The script writes directly to the SQLite DB the server reads
+    // (e2e.db in CI, local.db locally) inside one transaction.
+    execFileSync("node", ["tests/seed-patch-lens.cjs"], { stdio: "inherit" });
+
     const status = await modelStatus();
     if (status === null) {
         console.warn(`[global-setup] backend ${BACKEND} unreachable — skipping gpt2 warmup`);
@@ -49,7 +70,7 @@ export default async function globalSetup() {
     }
 
     console.log(`[global-setup] ${MODEL} is cold on NDIF — submitting warmup generation…`);
-    const resp = await fetch(`${BACKEND}/models/start-generate`, {
+    const resp = await fetchWithTimeout(`${BACKEND}/models/start-generate`, {
         method: "POST",
         headers: { "Content-Type": "application/json", "X-User-Email": "e2e@workbench" },
         body: JSON.stringify({ model: MODEL, prompt: "Hello", max_new_tokens: 1 }),
@@ -65,7 +86,7 @@ export default async function globalSetup() {
     const jobDeadline = Date.now() + JOB_TIMEOUT_MS;
     for (;;) {
         if (Date.now() > jobDeadline) throw new Error("[global-setup] gpt2 warmup timed out");
-        const r = await fetch(`${NDIF}/response/${body.job_id}`).catch(() => null);
+        const r = await fetchWithTimeout(`${NDIF}/response/${body.job_id}`).catch(() => null);
         if (r?.ok) {
             const job = (await r.json()) as { status?: string };
             if (job.status === "COMPLETED") break;

--- a/workbench/_web/tests/global-setup.ts
+++ b/workbench/_web/tests/global-setup.ts
@@ -1,0 +1,92 @@
+/**
+ * Playwright global setup: make sure gpt2 is actually deployed on NDIF before
+ * the real-NDIF specs run.
+ *
+ * The fixtures pick gpt2 in the header model selector, but since the
+ * model-selector redesign the picker hides non-runnable (cold) models — so if
+ * gpt2 happens to be cold on NDIF, every real-NDIF spec dies waiting for a
+ * menu item that will never appear. Warm it the same way the product's
+ * on-demand deploy does (see src/lib/api/deployApi.ts): fire a tiny
+ * /models/start-generate and poll the NDIF job until COMPLETED, then wait for
+ * the backend catalog (rebuilt from NDIF /status roughly every minute) to
+ * report the model as runnable.
+ *
+ * Backend unreachable → warn and continue: the seeded patch-lens specs don't
+ * need a backend, and the NDIF specs will fail with their own clear errors.
+ */
+
+const BACKEND = process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000";
+const NDIF = process.env.NEXT_PUBLIC_NDIF_URL || "https://api.ndif.us";
+const MODEL = "openai-community/gpt2";
+
+const JOB_TIMEOUT_MS = 15 * 60_000; // cold deploys are slow
+const CATALOG_TIMEOUT_MS = 3 * 60_000; // backend /status refresh is ~60s
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function modelStatus(): Promise<string | null> {
+    try {
+        const resp = await fetch(`${BACKEND}/models/`, {
+            headers: { "X-User-Email": "e2e@workbench" },
+        });
+        if (!resp.ok) return null;
+        const models = (await resp.json()) as { name: string; status: string }[];
+        return models.find((m) => m.name === MODEL)?.status ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export default async function globalSetup() {
+    const status = await modelStatus();
+    if (status === null) {
+        console.warn(`[global-setup] backend ${BACKEND} unreachable — skipping gpt2 warmup`);
+        return;
+    }
+    if (status !== "cold") {
+        console.log(`[global-setup] ${MODEL} status=${status} — no warmup needed`);
+        return;
+    }
+
+    console.log(`[global-setup] ${MODEL} is cold on NDIF — submitting warmup generation…`);
+    const resp = await fetch(`${BACKEND}/models/start-generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-User-Email": "e2e@workbench" },
+        body: JSON.stringify({ model: MODEL, prompt: "Hello", max_new_tokens: 1 }),
+    });
+    if (!resp.ok) throw new Error(`[global-setup] warmup submit failed: HTTP ${resp.status}`);
+    const body = (await resp.json()) as { job_id?: string | null; data?: unknown };
+    if (!body.job_id) {
+        // Local (non-remote) backend answers synchronously — nothing to warm.
+        if (body.data != null) return;
+        throw new Error("[global-setup] warmup did not start (no job id returned)");
+    }
+
+    const jobDeadline = Date.now() + JOB_TIMEOUT_MS;
+    for (;;) {
+        if (Date.now() > jobDeadline) throw new Error("[global-setup] gpt2 warmup timed out");
+        const r = await fetch(`${NDIF}/response/${body.job_id}`).catch(() => null);
+        if (r?.ok) {
+            const job = (await r.json()) as { status?: string };
+            if (job.status === "COMPLETED") break;
+            if (job.status === "ERROR" || job.status === "NNSIGHT_ERROR") {
+                throw new Error(`[global-setup] gpt2 warmup job failed: ${job.status}`);
+            }
+        }
+        await sleep(3000);
+    }
+    console.log("[global-setup] warmup job completed — waiting for catalog to flip…");
+
+    const catalogDeadline = Date.now() + CATALOG_TIMEOUT_MS;
+    for (;;) {
+        const s = await modelStatus();
+        if (s && s !== "cold") {
+            console.log(`[global-setup] ${MODEL} now status=${s}`);
+            return;
+        }
+        if (Date.now() > catalogDeadline) {
+            throw new Error("[global-setup] catalog never reported gpt2 as runnable");
+        }
+        await sleep(5000);
+    }
+}

--- a/workbench/_web/tests/patch-lens-features.spec.ts
+++ b/workbench/_web/tests/patch-lens-features.spec.ts
@@ -45,14 +45,13 @@ const tokenLabels = (page: Page) =>
     page.locator("#patch-lens-display .text-gray-700.truncate[title]");
 const historyStrips = (page: Page) => page.locator('[data-testid="lens-history-strip"]');
 
-const seed = () => {
-    // CI runs the default Playwright config with no seed step and no
-    // globalSetup, so seed the fixed charts + history here. seed-patch-lens.cjs
-    // loads .env and writes to the same SQLite DB the server reads (e2e.db in
-    // CI, local.db locally); its DELETE-then-INSERT is idempotent across
-    // retries. Runs after the webServer is up, so the server sees the committed
-    // rows on the next query.
-    execFileSync("node", ["tests/seed-patch-lens.cjs"], { stdio: "inherit" });
+// The full seed runs ONCE in tests/global-setup.ts, before any worker starts
+// — reseeding from per-describe beforeAll hooks raced parallel workers (a
+// later describe's DELETE-then-INSERT could reset a chart another worker was
+// mid-test on). Only the F1 restore test mutates its chart, so it reseeds
+// itself, scoped to its own chart.
+const reseedHistoryChart = () => {
+    execFileSync("node", ["tests/seed-patch-lens.cjs", "--history-only"], { stdio: "inherit" });
 };
 
 /** Pin the shared toolbar steps so the grid density (and Argos screenshots)
@@ -65,8 +64,6 @@ async function pinSteps(page: Page, tokenStep: number, layerStep: number) {
 }
 
 test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
-    test.beforeAll(seed);
-
     test.beforeEach(async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 720 });
         // The Patch Lens tutorial auto-starts on first visit (reactour) and
@@ -95,7 +92,9 @@ test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
         page,
     }) => {
         // Restoring persists onto the chart row — run against the F1-only
-        // clone so the shared chart stays pristine for the other specs.
+        // clone so the shared chart stays pristine for the other specs, and
+        // reseed that clone so retries start from the un-restored state.
+        reseedHistoryChart();
         await page.goto(HISTORY_URL);
         await expect(tokenLabels(page).first()).toBeVisible({ timeout: 30_000 });
 
@@ -216,8 +215,6 @@ test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
 });
 
 test.describe("patch-lens intervention (seeded restore, no NDIF)", () => {
-    test.beforeAll(seed);
-
     test.beforeEach(async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 720 });
         await page.addInitScript(([key]) => localStorage.setItem(key, "true"), [TUTORIAL_KEY]);
@@ -258,8 +255,6 @@ test.describe("patch-lens intervention (seeded restore, no NDIF)", () => {
 });
 
 test.describe("patch-lens tutorial", () => {
-    test.beforeAll(seed);
-
     test.beforeEach(async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 720 });
         // No completed flag → the tour auto-starts (fresh browser context).

--- a/workbench/_web/tests/patch-lens-features.spec.ts
+++ b/workbench/_web/tests/patch-lens-features.spec.ts
@@ -284,4 +284,26 @@ test.describe("patch-lens tutorial", () => {
         ).toBeVisible();
         await page.getByRole("button", { name: "Close tour" }).click();
     });
+
+    test("reopening the tutorial restarts at step 1 (not the step it was closed on)", async ({
+        page,
+    }) => {
+        // Auto-start opens chapter 1 at step 1.
+        await expect(page.getByText(/Welcome to Patch Lens\./)).toBeVisible({ timeout: 15_000 });
+        await expect(page.getByText("1 / 6")).toBeVisible();
+
+        // Advance a couple of steps, then close mid-tour.
+        await page.getByRole("button", { name: "Next", exact: true }).click();
+        await page.getByRole("button", { name: "Next", exact: true }).click();
+        await expect(page.getByText("3 / 6")).toBeVisible();
+        await page.getByRole("button", { name: "Close tour" }).click();
+
+        // Reopen the same chapter from the Tutorial menu: it must restart at
+        // step 1, not resume at step 3 (reactour retains the last step index).
+        await page.getByRole("button", { name: "Tutorial" }).click();
+        await page.getByRole("menuitem", { name: "Reading the lens" }).click();
+        await expect(page.getByText(/Welcome to Patch Lens\./)).toBeVisible();
+        await expect(page.getByText("1 / 6")).toBeVisible();
+        await page.getByRole("button", { name: "Close tour" }).click();
+    });
 });

--- a/workbench/_web/tests/patch-lens-features.spec.ts
+++ b/workbench/_web/tests/patch-lens-features.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
+import { argosScreenshot } from "@argos-ci/playwright";
 import { execFileSync } from "node:child_process";
 
 /**
@@ -10,36 +11,68 @@ import { execFileSync } from "node:child_process";
  *   B1: the final-token row is rendered and in-viewport (not clipped).
  *   F1: the history rail stacks one strip per past run, newest highlighted,
  *       and clicking a strip loads its prompt back into the source composer.
+ *
+ * Pilot-feedback UI spec (2026-07):
+ *   - spaces inside tokens render as ␣ everywhere
+ *   - axis titles carry the downsampling step: "Layer (Step: X)" / "Tokens (Step: X)"
+ *   - collapsed rows/columns show amber, labeled, clickable break-bands
+ *   - the top-token panel marks final predictions with labeled borders
+ *   - the brown final-token cell tint is gone
+ *   - a restored intervention renders the result grid and auto-scrolls to it
+ *   - tutorial: chapter 1 ("Reading the lens") auto-runs and opens with
+ *     "Welcome to Patch Lens."; chapter 2 is reachable from the Tutorial menu
+ *
+ * Visual regression (Argos): the lens heatmap view, the intervention (patching)
+ * view, and the prompt history (rail + compare overlay).
  */
 
 const WS = "11111111-1111-4111-8111-111111111111";
 const CHART = "22222222-2222-4222-8222-222222222222";
+const PATCHED_CHART = "22222222-2222-4222-8222-222222222223";
+// F1 restores a history strip, which PERSISTS onto the chart row — the
+// mutating test gets its own seeded clone so the other specs stay
+// deterministic under parallel workers.
+const HISTORY_CHART = "22222222-2222-4222-8222-222222222224";
 const URL = `/workbench/${WS}/patch-lens/${CHART}`;
+const PATCHED_URL = `/workbench/${WS}/patch-lens/${PATCHED_CHART}`;
+const HISTORY_URL = `/workbench/${WS}/patch-lens/${HISTORY_CHART}`;
+
+// Keep in sync with stores/usePatchLensTutorial.ts.
+const TUTORIAL_KEY = "workbench:patch-lens-tutorial-completed:v2";
 
 // Token-column row labels are the only [title] elements in the display.
 const tokenLabels = (page: Page) =>
     page.locator("#patch-lens-display .text-gray-700.truncate[title]");
 const historyStrips = (page: Page) => page.locator('[data-testid="lens-history-strip"]');
 
-test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
+const seed = () => {
     // CI runs the default Playwright config with no seed step and no
-    // globalSetup, so seed the fixed chart + history here. seed-patch-lens.cjs
+    // globalSetup, so seed the fixed charts + history here. seed-patch-lens.cjs
     // loads .env and writes to the same SQLite DB the server reads (e2e.db in
     // CI, local.db locally); its DELETE-then-INSERT is idempotent across
     // retries. Runs after the webServer is up, so the server sees the committed
     // rows on the next query.
-    test.beforeAll(() => {
-        execFileSync("node", ["tests/seed-patch-lens.cjs"], { stdio: "inherit" });
-    });
+    execFileSync("node", ["tests/seed-patch-lens.cjs"], { stdio: "inherit" });
+};
+
+/** Pin the shared toolbar steps so the grid density (and Argos screenshots)
+ *  don't depend on the autofit's viewport-derived downsampling. The toolbar
+ *  renders exactly two number inputs: Token Step then Layer Step. */
+async function pinSteps(page: Page, tokenStep: number, layerStep: number) {
+    const inputs = page.locator('#patch-lens-display input[type="number"]');
+    await inputs.nth(0).fill(String(tokenStep));
+    await inputs.nth(1).fill(String(layerStep));
+}
+
+test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
+    test.beforeAll(seed);
 
     test.beforeEach(async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 720 });
         // The Patch Lens tutorial auto-starts on first visit (reactour) and
         // overlays the page, blocking the heatmap + rail. Mark it completed so
-        // it stays closed — these tests aren't exercising the tour.
-        await page.addInitScript(() =>
-            localStorage.setItem("workbench:patch-lens-tutorial-completed:v1", "true"),
-        );
+        // it stays closed — the tutorial has its own describe block below.
+        await page.addInitScript(([key]) => localStorage.setItem(key, "true"), [TUTORIAL_KEY]);
         await page.goto(URL);
         // Heatmap rendered once token labels appear.
         await expect(tokenLabels(page).first()).toBeVisible({ timeout: 30_000 });
@@ -61,6 +94,11 @@ test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
     test("F1: history rail stacks runs; newest highlighted; click loads prompt", async ({
         page,
     }) => {
+        // Restoring persists onto the chart row — run against the F1-only
+        // clone so the shared chart stays pristine for the other specs.
+        await page.goto(HISTORY_URL);
+        await expect(tokenLabels(page).first()).toBeVisible({ timeout: 30_000 });
+
         // The prompt history now renders inline under the Run button (no
         // collapse/expand step) — the strips are present immediately.
         const strips = historyStrips(page);
@@ -83,5 +121,172 @@ test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
         const sourceArea = page.locator("#patch-lens-source-prompt");
         await expect(sourceArea).toContainText("Rome");
         await expect(sourceArea).not.toContainText("Paris");
+    });
+
+    test("tokens render their spaces as ␣ (row labels and cells)", async ({ page }) => {
+        // Show every row: autofit hides odd token indices at this viewport,
+        // and " Eiffel" is row index 1.
+        await pinSteps(page, 1, 8);
+
+        // Row label for the " Eiffel" token: raw token stays in title, display
+        // shows the open-box marker.
+        const eiffel = tokenLabels(page).filter({ hasText: "Eiffel" }).first();
+        await expect(eiffel).toHaveAttribute("title", " Eiffel");
+        await expect(eiffel).toHaveText("␣Eiffel");
+
+        // Heatmap cell text (cell spans carry the raw token in title): row 0's
+        // top-1 prediction is " Eiffel", displayed as ␣Eiffel.
+        const eiffelCell = page
+            .locator('#patch-lens-display span.tracking-tight[title=" Eiffel"]')
+            .first();
+        await eiffelCell.scrollIntoViewIfNeeded();
+        await expect(eiffelCell).toHaveText("␣Eiffel");
+    });
+
+    test("axis titles show the token/layer step", async ({ page }) => {
+        const display = page.locator("#patch-lens-display");
+        // "Layer (Step: X)" renders above AND below the grid.
+        await expect(display.getByText(/^Layer \(Step: \d+\)$/)).toHaveCount(2);
+        // Rotated y-axis title outside the scroll container.
+        await expect(display.getByText(/^Tokens \(Step: \d+\)$/)).toHaveCount(1);
+    });
+
+    test("collapsed rows/columns show amber labeled expanders that expand on click", async ({
+        page,
+    }) => {
+        // The 12-token × 32-layer fixture at 1280×720 always downsamples, so
+        // both gap expanders exist. The row expander carries a legible count
+        // label ("⋯ N hidden"), not the old faint 9px text.
+        const rowExpander = page.getByTestId("token-gap-expander").first();
+        await expect(rowExpander).toBeVisible();
+        await expect(rowExpander).toHaveText(/⋯ \d+ hidden/);
+
+        const colExpander = page.getByTestId("layer-gap-expander").first();
+        await expect(colExpander).toBeVisible();
+
+        // Clicking an expander reveals the hidden rows/columns.
+        const rowsBefore = await tokenLabels(page).count();
+        await rowExpander.click();
+        expect(await tokenLabels(page).count()).toBeGreaterThan(rowsBefore);
+
+        const colsBefore = await page.getByTestId("layer-gap-expander").count();
+        await colExpander.click();
+        // Expanding a column gap removes that expander (its layers are shown).
+        expect(await page.getByTestId("layer-gap-expander").count()).toBeLessThan(colsBefore);
+    });
+
+    test("top-token panel marks final predictions with labeled borders; no brown legend", async ({
+        page,
+    }) => {
+        // The brown final-token tint (and its legend key) is gone.
+        await expect(page.getByText("Final output token")).toHaveCount(0);
+
+        // Click the final-layer cell of the last row (the bottom-right cell —
+        // its top-1 is the run's final prediction, which is both this row's
+        // final prediction AND the model's output).
+        const lastCell = page.locator("#patch-lens-display span.tracking-tight[title]").last();
+        await lastCell.scrollIntoViewIfNeeded();
+        await lastCell.click();
+
+        // The draggable top-tokens panel opens with both labeled markers.
+        await expect(page.getByText("Selected Position")).toBeVisible();
+        await expect(page.getByText("Final prediction (this position)")).toBeVisible();
+        await expect(page.getByText("Model's final output")).toBeVisible();
+    });
+
+    test("visual: lens heatmap view", async ({ page }) => {
+        // Pin the density so the screenshot doesn't ride on autofit.
+        await pinSteps(page, 2, 8);
+        await expect(page.getByTestId("token-gap-expander").first()).toBeVisible();
+        await argosScreenshot(page, "patch-lens-lens-view", { fullPage: false });
+    });
+
+    test("visual: prompt history rail and compare overlay", async ({ page }) => {
+        const rail = page.getByTestId("lens-history-list");
+        await expect(historyStrips(page)).toHaveCount(3);
+        await argosScreenshot(page, "patch-lens-history-rail", {
+            element: rail,
+        });
+
+        // Compare overlay: full-screen last-row comparison of the three runs.
+        await page.getByRole("button", { name: /compare/i }).click();
+        await expect(page.getByText("Compare prompts")).toBeVisible();
+        await argosScreenshot(page, "patch-lens-history-compare", { fullPage: false });
+    });
+});
+
+test.describe("patch-lens intervention (seeded restore, no NDIF)", () => {
+    test.beforeAll(seed);
+
+    test.beforeEach(async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.addInitScript(([key]) => localStorage.setItem(key, "true"), [TUTORIAL_KEY]);
+        await page.goto(PATCHED_URL);
+        await expect(tokenLabels(page).first()).toBeVisible({ timeout: 30_000 });
+    });
+
+    test("restored intervention renders the result grid and auto-scrolls it into view", async ({
+        page,
+    }) => {
+        // Source and target grids render side by side (grid card headings).
+        await expect(page.getByRole("heading", { name: "Source Prompt" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Target Prompt" })).toBeVisible();
+
+        // The persisted patch restores as a controlled result: the third grid
+        // appears without any drag, and the explorer scrolls it into view.
+        const resultHeader = page.getByRole("heading", { name: "Result (Intervened)" });
+        await expect(resultHeader).toBeVisible();
+        await expect(resultHeader).toBeInViewport({ timeout: 10_000 });
+        await expect(page.getByRole("button", { name: /reset intervention/i })).toBeVisible();
+
+        // The result sidebar auto-selects the last cell — its top token is the
+        // patched-in answer, marked as the model's final output.
+        await expect(page.getByText("Model's final output").first()).toBeVisible();
+    });
+
+    test("visual: intervention (patching) view", async ({ page }) => {
+        const resultHeader = page.getByRole("heading", { name: "Result (Intervened)" });
+        await expect(resultHeader).toBeVisible();
+        // Pin the density (re-laying out the grids), then bring the result
+        // into frame ourselves — the auto-scroll behavior has its own test.
+        await pinSteps(page, 1, 8);
+        await resultHeader.scrollIntoViewIfNeeded();
+        // Let the reveal/cascade animations settle so the screenshot is stable.
+        await page.waitForTimeout(1500);
+        await argosScreenshot(page, "patch-lens-intervention", { fullPage: false });
+    });
+});
+
+test.describe("patch-lens tutorial", () => {
+    test.beforeAll(seed);
+
+    test.beforeEach(async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 720 });
+        // No completed flag → the tour auto-starts (fresh browser context).
+        await page.goto(URL);
+    });
+
+    test("chapter 1 auto-runs with Patch Lens welcome; chapter 2 opens from the Tutorial menu", async ({
+        page,
+    }) => {
+        // Auto-start fires ~600ms after mount.
+        await expect(page.getByText(/Welcome to Patch Lens\./)).toBeVisible({
+            timeout: 15_000,
+        });
+        await page.getByRole("button", { name: "Close tour" }).click();
+
+        // The Tutorial button is now a menu listing both chapters.
+        await page.getByRole("button", { name: "Tutorial" }).click();
+        const lensChapter = page.getByRole("menuitem", { name: "Reading the lens" });
+        const patchChapter = page.getByRole("menuitem", { name: "Activation patching" });
+        await expect(lensChapter).toBeVisible();
+        await expect(patchChapter).toBeVisible();
+
+        // Launching chapter 2 shows the activation-patching intro step.
+        await patchChapter.click();
+        await expect(
+            page.getByText(/Activation patching takes a piece of internal state/),
+        ).toBeVisible();
+        await page.getByRole("button", { name: "Close tour" }).click();
     });
 });

--- a/workbench/_web/tests/patch-lens-trim.spec.ts
+++ b/workbench/_web/tests/patch-lens-trim.spec.ts
@@ -48,8 +48,10 @@ test.describe("patch-lens prompt trimming (real NDIF)", () => {
     test.beforeEach(async ({ page }) => {
         await page.setViewportSize({ width: 1280, height: 900 });
         // Keep the auto-starting tutorial closed so it doesn't overlay the controls.
+        // Key must match usePatchLensTutorial.ts (bumped to v2 for the two-chapter
+        // split); the stale v1 key let the tour auto-open and block these controls.
         await page.addInitScript(() =>
-            localStorage.setItem("workbench:patch-lens-tutorial-completed:v1", "true"),
+            localStorage.setItem("workbench:patch-lens-tutorial-completed:v2", "true"),
         );
         await page.goto(URL);
     });

--- a/workbench/_web/tests/seed-patch-lens.cjs
+++ b/workbench/_web/tests/seed-patch-lens.cjs
@@ -103,31 +103,40 @@ const chartData = {
     activeLensRunId: NEWEST_RUN_ID,
 };
 
+// --history-only: reset ONLY the F1 chart (and its runs). The F1 restore test
+// mutates its chart row, so it reseeds itself before each attempt — scoped to
+// its own chart so a reseed can never yank shared charts out from under the
+// other specs running in parallel workers (the full seed runs once, in
+// tests/global-setup.ts, before any worker starts).
+const historyOnly = process.argv.includes("--history-only");
+
 const db = new Database(DB_PATH);
-// Multiple Playwright workers run this concurrently (each describe block's
-// beforeAll). Serialize writers: wait out a peer's transaction instead of
-// throwing SQLITE_BUSY, and make the whole DELETE-then-INSERT atomic so a
-// half-seeded state is never visible (racing DELETE/INSERT threw UNIQUE
-// constraint failures on lens_runs.id).
+// Serialize concurrent writers (e.g. an F1 retry reseeding while another
+// worker reads): wait out a peer's transaction instead of throwing
+// SQLITE_BUSY, and make the whole DELETE-then-INSERT atomic so a half-seeded
+// state is never visible (racing DELETE/INSERT threw UNIQUE constraint
+// failures on lens_runs.id).
 db.pragma("busy_timeout = 15000");
 db.exec("BEGIN IMMEDIATE");
 const now = Date.now();
 
-db.exec("DELETE FROM lens_runs WHERE chart_id = '" + CHART_ID + "'");
-db.exec("DELETE FROM lens_runs WHERE chart_id = '" + PATCHED_CHART_ID + "'");
 db.exec("DELETE FROM lens_runs WHERE chart_id = '" + HISTORY_CHART_ID + "'");
-db.prepare("DELETE FROM charts WHERE id = ?").run(CHART_ID);
-db.prepare("DELETE FROM charts WHERE id = ?").run(PATCHED_CHART_ID);
 db.prepare("DELETE FROM charts WHERE id = ?").run(HISTORY_CHART_ID);
-db.prepare("DELETE FROM workspaces WHERE id = ?").run(WS_ID);
+if (!historyOnly) {
+    db.exec("DELETE FROM lens_runs WHERE chart_id = '" + CHART_ID + "'");
+    db.exec("DELETE FROM lens_runs WHERE chart_id = '" + PATCHED_CHART_ID + "'");
+    db.prepare("DELETE FROM charts WHERE id = ?").run(CHART_ID);
+    db.prepare("DELETE FROM charts WHERE id = ?").run(PATCHED_CHART_ID);
+    db.prepare("DELETE FROM workspaces WHERE id = ?").run(WS_ID);
 
-db.prepare(
-    "INSERT INTO workspaces (id, user_id, name, public, updated_at) VALUES (?, ?, ?, ?, ?)",
-).run(WS_ID, "dev@localhost", "E2E Patch Lens", 0, now);
+    db.prepare(
+        "INSERT INTO workspaces (id, user_id, name, public, updated_at) VALUES (?, ?, ?, ?, ?)",
+    ).run(WS_ID, "dev@localhost", "E2E Patch Lens", 0, now);
 
-db.prepare(
-    "INSERT INTO charts (id, workspace_id, name, data, type, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-).run(CHART_ID, WS_ID, "Eiffel Tower", JSON.stringify(chartData), "patch-lens", 0, now, now);
+    db.prepare(
+        "INSERT INTO charts (id, workspace_id, name, data, type, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    ).run(CHART_ID, WS_ID, "Eiffel Tower", JSON.stringify(chartData), "patch-lens", 0, now, now);
+}
 
 // Three history entries (successive prompt versions) with distinct timestamps.
 const insRun = db.prepare(
@@ -160,15 +169,17 @@ versions.forEach((v, i) => {
         params: { topk: 10, includeEntropy: true },
     };
     const data = { source: buildLensData(v.tok) };
-    insRun.run(
-        v.id,
-        WS_ID,
-        CHART_ID,
-        MODEL,
-        JSON.stringify(summary),
-        JSON.stringify(data),
-        now + i * 1000,
-    );
+    if (!historyOnly) {
+        insRun.run(
+            v.id,
+            WS_ID,
+            CHART_ID,
+            MODEL,
+            JSON.stringify(summary),
+            JSON.stringify(data),
+            now + i * 1000,
+        );
+    }
     // Mirror the same history onto the F1-only chart (distinct run ids).
     insRun.run(
         `${HISTORY_RUN_PREFIX}${i + 1}`,
@@ -194,6 +205,15 @@ db.prepare(
     now,
     now,
 );
+
+if (historyOnly) {
+    db.exec("COMMIT");
+    console.log(
+        `Reseeded history chart ${HISTORY_CHART_ID} (${versions.length} run rows) -> ${DB_PATH}`,
+    );
+    db.close();
+    process.exit(0);
+}
 
 // ---------------------------------------------------------------------------
 // Patched chart: source + target + a persisted intervention whose patched
@@ -264,7 +284,9 @@ insRun.run(
 );
 
 db.exec("COMMIT");
+// Run rows: versions on the main chart + their history-chart mirrors + the
+// patched run.
 console.log(
-    `Seeded workspace ${WS_ID}, charts ${CHART_ID} + ${PATCHED_CHART_ID} (patch-lens), ${versions.length + 1} run rows -> ${DB_PATH}`,
+    `Seeded workspace ${WS_ID}, charts ${CHART_ID} + ${PATCHED_CHART_ID} + ${HISTORY_CHART_ID} (patch-lens), ${versions.length * 2 + 1} run rows -> ${DB_PATH}`,
 );
 db.close();

--- a/workbench/_web/tests/seed-patch-lens.cjs
+++ b/workbench/_web/tests/seed-patch-lens.cjs
@@ -23,6 +23,20 @@ const MODEL = "meta-llama/Llama-3.1-8B";
 // The newest run id — the chart's activeLensRunId points here.
 const NEWEST_RUN_ID = "33333333-3333-4333-8333-333333333333";
 
+// Second chart: a source+target pair with a persisted intervention + patched
+// result, so the E2E can exercise the full activation-patching view (result
+// grid, auto-scroll, patched-cell styling) via the restore path — no NDIF.
+const PATCHED_CHART_ID = "22222222-2222-4222-8222-222222222223";
+const PATCHED_RUN_ID = "44444444-4444-4444-8444-444444444444";
+
+// Third chart: an identical clone of the first, used ONLY by the F1
+// history-restore test. Restoring a strip PERSISTS onto the chart row
+// (prompts + activeLensRunId), so giving the mutating test its own chart
+// keeps the other specs (and the Argos screenshots) deterministic under
+// fullyParallel workers.
+const HISTORY_CHART_ID = "22222222-2222-4222-8222-222222222224";
+const HISTORY_RUN_PREFIX = "55555555-5555-4555-8555-55555555555";
+
 // A 12-token prompt over 32 layers — big enough that the OLD auto-fit clipped
 // the final row at a constrained viewport height (the B1 condition).
 const TOKENS = [
@@ -45,8 +59,8 @@ const LAYERS = Array.from({ length: N_LAYERS }, (_, i) => i);
 // Build nnsightful-shaped LogitLensData: input, layers, tracked, topk.
 // For each position, a couple of candidate tokens with per-layer probabilities
 // that ramp toward the final layer (so cells have visible color).
-function buildLensData(finalToken) {
-    const input = TOKENS.slice();
+function buildLensData(finalToken, tokens = TOKENS) {
+    const input = tokens.slice();
     const topk = LAYERS.map((li) =>
         input.map((_, pos) => {
             const cand =
@@ -90,10 +104,21 @@ const chartData = {
 };
 
 const db = new Database(DB_PATH);
+// Multiple Playwright workers run this concurrently (each describe block's
+// beforeAll). Serialize writers: wait out a peer's transaction instead of
+// throwing SQLITE_BUSY, and make the whole DELETE-then-INSERT atomic so a
+// half-seeded state is never visible (racing DELETE/INSERT threw UNIQUE
+// constraint failures on lens_runs.id).
+db.pragma("busy_timeout = 15000");
+db.exec("BEGIN IMMEDIATE");
 const now = Date.now();
 
 db.exec("DELETE FROM lens_runs WHERE chart_id = '" + CHART_ID + "'");
+db.exec("DELETE FROM lens_runs WHERE chart_id = '" + PATCHED_CHART_ID + "'");
+db.exec("DELETE FROM lens_runs WHERE chart_id = '" + HISTORY_CHART_ID + "'");
 db.prepare("DELETE FROM charts WHERE id = ?").run(CHART_ID);
+db.prepare("DELETE FROM charts WHERE id = ?").run(PATCHED_CHART_ID);
+db.prepare("DELETE FROM charts WHERE id = ?").run(HISTORY_CHART_ID);
 db.prepare("DELETE FROM workspaces WHERE id = ?").run(WS_ID);
 
 db.prepare(
@@ -144,9 +169,102 @@ versions.forEach((v, i) => {
         JSON.stringify(data),
         now + i * 1000,
     );
+    // Mirror the same history onto the F1-only chart (distinct run ids).
+    insRun.run(
+        `${HISTORY_RUN_PREFIX}${i + 1}`,
+        WS_ID,
+        HISTORY_CHART_ID,
+        MODEL,
+        JSON.stringify(summary),
+        JSON.stringify(data),
+        now + i * 1000,
+    );
 });
 
+// The F1-only clone of the first chart (see HISTORY_CHART_ID above).
+db.prepare(
+    "INSERT INTO charts (id, workspace_id, name, data, type, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+).run(
+    HISTORY_CHART_ID,
+    WS_ID,
+    "Eiffel Tower (history)",
+    JSON.stringify({ ...chartData, activeLensRunId: `${HISTORY_RUN_PREFIX}3` }),
+    "patch-lens",
+    2,
+    now,
+    now,
+);
+
+// ---------------------------------------------------------------------------
+// Patched chart: source + target + a persisted intervention whose patched
+// heatmap is stored on the run row. PatchLensDisplay restores this as a
+// controlled result, so the explorer renders the full intervention view
+// (cone, arrow, result grid + sidebar) straight from the DB.
+const SRC_TOKENS = ["The", " Eiffel", " Tower", " is", " in", " the", " city", " of"];
+const TGT_TOKENS = ["The", " Big", " Ben", " is", " in", " the", " city", " of"];
+// Layer 8 stays visible at Layer Step 8 (the spec pins steps via the toolbar);
+// the last token position is always rendered regardless of token step.
+const INTERVENTION = { srcTokenPos: 7, srcLayer: 8, tgtTokenPos: 7, tgtLayer: 8 };
+
+function promptSummary(tokens, finalToken) {
+    const cells = LAYERS.map((li) => ({
+        token: li > N_LAYERS / 2 ? finalToken : " the",
+        prob: Math.round((0.15 + (0.8 * li) / (N_LAYERS - 1)) * 1000) / 1000,
+    }));
+    return {
+        prompt: tokens.join(""),
+        finalToken,
+        lastRow: { layers: LAYERS, cells },
+    };
+}
+
+const patchedChartData = {
+    sourcePrompt: SRC_TOKENS.join(""),
+    targetPrompt: TGT_TOKENS.join(""),
+    lastRunSourcePrompt: SRC_TOKENS.join(""),
+    lastRunTargetPrompt: TGT_TOKENS.join(""),
+    intervention: INTERVENTION,
+    activeLensRunId: PATCHED_RUN_ID,
+};
+
+db.prepare(
+    "INSERT INTO charts (id, workspace_id, name, data, type, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+).run(
+    PATCHED_CHART_ID,
+    WS_ID,
+    "Eiffel vs Big Ben (patched)",
+    JSON.stringify(patchedChartData),
+    "patch-lens",
+    1,
+    now,
+    now,
+);
+
+const patchedSummary = {
+    source: promptSummary(SRC_TOKENS, " Paris"),
+    target: promptSummary(TGT_TOKENS, " London"),
+    intervention: INTERVENTION,
+    // The classic outcome: the patched target now predicts the source answer.
+    interventionResult: promptSummary(TGT_TOKENS, " Paris"),
+    params: { topk: 10, includeEntropy: true },
+};
+const patchedData = {
+    source: buildLensData(" Paris", SRC_TOKENS),
+    target: buildLensData(" London", TGT_TOKENS),
+    interventionResult: buildLensData(" Paris", TGT_TOKENS),
+};
+insRun.run(
+    PATCHED_RUN_ID,
+    WS_ID,
+    PATCHED_CHART_ID,
+    MODEL,
+    JSON.stringify(patchedSummary),
+    JSON.stringify(patchedData),
+    now,
+);
+
+db.exec("COMMIT");
 console.log(
-    `Seeded workspace ${WS_ID}, chart ${CHART_ID} (patch-lens), ${versions.length} history rows -> ${DB_PATH}`,
+    `Seeded workspace ${WS_ID}, charts ${CHART_ID} + ${PATCHED_CHART_ID} (patch-lens), ${versions.length + 1} run rows -> ${DB_PATH}`,
 );
 db.close();


### PR DESCRIPTION
## What

Addresses the usability observations from the faculty-workshop pilot testing of Patch Lens, and expands the e2e suite to lock the new spec in (with Argos visual regression on the logit lens view, the patching view, and the prompt history).

### Widget (edulogitlens, pinned `bbb5b61` → `61be83a`)
- **Spaces in tokens are visible everywhere**: `␣` (U+2423) in row labels, cells, top-k lists, intervention chips, compare overlay (`↵`/`⇥` for newline/tab so whitespace-only tokens never vanish).
- **Hidden rows/columns are loud**: collapsed gaps get amber break-bands with legible "⋯ N hidden" labels; the whole band is clickable to expand (both axes).
- **Axis labels carry the step**: "Layer (Step: X)" top and bottom, plus a new rotated "Tokens (Step: X)" y-axis title that stays visible under horizontal scroll.
- **Pixel-perfect highlight bands**: the crosshair/cone overlays are computed from measured cell rects instead of index-multiplied arithmetic, killing the accumulating per-row drift at non-100% zoom.
- **No background around the patched cell**: a white exclusion ring is carved out of the highlight bands around the intervention cell.
- **Labeled final-prediction borders in the top-k lists**: emerald "Final prediction (this position)" and orange "Model's final output" chips + borders.
- **Brown final-token tint removed** (cells + legend key).
- **The intervention result auto-scrolls into view** once auto-fit layout settles (works for both live drags and restored patches).

### Workbench
- **Tutorial restructured**: chapter 1 "Reading the lens" auto-runs once and opens with "Welcome to Patch Lens.", ending by encouraging logit-lens exploration first; chapter 2 "Activation patching" is launched from the Tutorial button (now a dropdown menu). Completion key bumped to `:v2`.
- Compare overlay uses the shared `␣` formatter.

### E2E
- `patch-lens-features.spec.ts` grows from 2 to 11 tests covering the full pilot-feedback spec, including a seeded source+target+intervention chart that renders the complete patching view (result grid, sidebar, auto-scroll) with no NDIF.
- **New Argos shots**: `patch-lens-lens-view`, `patch-lens-intervention`, `patch-lens-history-rail`, `patch-lens-history-compare`.
- `tests/global-setup.ts` warms gpt2 before the real-NDIF specs — the redesigned model picker hides cold models, so a cold gpt2 previously made every NDIF spec hang in `waitForModelsLoaded`. No-op when gpt2 is hot.
- Seed script is transactional (parallel workers raced the per-describe seed into `UNIQUE` violations), and the mutating F1 restore test gets its own seeded chart clone.

## Testing

- Full Playwright suite green locally against real NDIF: **18 passed** (including a cold-start gpt2 warmup path).
- `bunx tsc --noEmit`, eslint, prettier: no new findings; `bun test` 50/50.
- Visually verified the intervention screenshot: ␣ markers, amber bands, step-labeled axes, patch arrow/chips, both labeled borders, no brown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split the Patch Lens walkthrough into two chapters, with a chapter picker to start at the right step.
  * Added a “Try an example” button for first-time Patch Lens onboarding.
* **Bug Fixes**
  * Improved compact token rendering, including consistent space display.
* **UI Improvements**
  * Enhanced the walkthrough popover with step help/tooltip controls and refined sidebar/tour UI.
* **Tests**
  * Expanded Patch Lens E2E coverage with additional seeded-state assertions, visual snapshots, and more reliable model warmup/setup for regression runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->