### PR TITLE
Mask non-deterministic chart data in visual (Argos) tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,6 +91,7 @@ jobs:
             "NEXT_PUBLIC_BASE_URL=http://localhost:3000" \
             "NEXT_PUBLIC_BACKEND_URL=http://localhost:8000" \
             "HF_TOKEN=${HF_TOKEN}" \
+            "NEXT_PUBLIC_VISUAL_TEST=true" \
             > .env
           cp .env workbench/_web/.env
           # Backend reads its own .env; mirror the secrets so CONFIG=e2e

--- a/workbench/_web/src/app/workbench/[workspaceId]/activation-patching/[chartId]/components/ActivationPatchingDisplay.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/activation-patching/[chartId]/components/ActivationPatchingDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useParams } from "next/navigation";
 import { useQuery, useIsMutating } from "@tanstack/react-query";
 import { getChartById, getConfigForChart } from "@/lib/queries/chartQueries";
@@ -16,6 +16,7 @@ import { useUpdateChartConfig } from "@/lib/api/configApi";
 import { NotebookExporter } from "@/components/NotebookExporter";
 import { ChartModelPill } from "@/components/charts/ChartModelPill";
 import { chartModelFromConfig, isChartStale } from "@/lib/configModelDiff";
+import { isVisualTestMode, maskActivationPatchingDataForVisualTest } from "@/lib/visualTest";
 import { useModelsQuery } from "@/lib/api/modelsApi";
 import { useWorkspace } from "@/stores/useWorkspace";
 
@@ -78,6 +79,14 @@ export function ActivationPatchingDisplay() {
     const patchingConfig = config as ActivationPatchingConfig | undefined;
     const hasData =
         patchingChart?.data && "lines" in patchingChart.data && patchingChart.data.lines.length > 0;
+
+    // In visual-test mode, flatten the noisy plotted series so Argos snapshots
+    // are deterministic against real NDIF (chart chrome stays, lines ignored).
+    const widgetData = useMemo(() => {
+        const raw = patchingChart?.data;
+        if (!raw || !hasData) return raw;
+        return isVisualTestMode() ? maskActivationPatchingDataForVisualTest(raw) : raw;
+    }, [patchingChart?.data, hasData]);
 
     // Get the chart's saved name (treat "Untitled Chart" default as empty)
     const rawChartName = patchingChart?.name || "";
@@ -280,7 +289,7 @@ export function ActivationPatchingDisplay() {
             {/* Chart area */}
             <div className="flex-1 p-4 min-h-0">
                 <ActivationPatchingWidget
-                    data={patchingChart!.data!}
+                    data={widgetData!}
                     darkMode={isDarkMode}
                     transparentBackground
                     mode={

--- a/workbench/_web/src/app/workbench/[workspaceId]/lens2/[chartId]/components/Lens2Display.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/lens2/[chartId]/components/Lens2Display.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useParams } from "next/navigation";
 import { useQuery, useIsMutating } from "@tanstack/react-query";
 import { getChartById, getConfigForChart } from "@/lib/queries/chartQueries";
@@ -16,6 +16,7 @@ import { useUpdateChartName } from "@/lib/api/chartApi";
 import { useUpdateChartConfig } from "@/lib/api/configApi";
 import { ChartModelPill } from "@/components/charts/ChartModelPill";
 import { chartModelFromConfig, isChartStale } from "@/lib/configModelDiff";
+import { isVisualTestMode, maskLogitLensDataForVisualTest } from "@/lib/visualTest";
 
 interface Lens2Chart {
     id: string;
@@ -66,6 +67,14 @@ export function Lens2Display() {
     const lens2Chart = chart as Lens2Chart | undefined;
     const lens2Config = config as Lens2Config | undefined;
     const hasData = lens2Chart?.data && "meta" in lens2Chart.data;
+
+    // In visual-test mode, blank the noisy heatmap values so Argos snapshots
+    // are deterministic against real NDIF (keeps only the final prediction).
+    const widgetData = useMemo(() => {
+        const raw = lens2Chart?.data as LogitLensData | undefined;
+        if (!raw || !hasData) return raw;
+        return isVisualTestMode() ? maskLogitLensDataForVisualTest(raw) : raw;
+    }, [lens2Chart?.data, hasData]);
 
     // ── Persist heatmap UI state (pins, selection, layer window, appearance)
     // into the chart config, mirroring ActivationPatchingDisplay. Debounced
@@ -218,7 +227,7 @@ export function Lens2Display() {
                 {stale && chartModel && <ChartModelPill modelName={chartModel} />}
             </div>
             <LogitLensWidget
-                data={lens2Chart.data! as LogitLensData}
+                data={widgetData as LogitLensData}
                 darkMode={isDarkMode}
                 uiState={savedUiState}
                 onStateChange={handleStateChange}

--- a/workbench/_web/src/lib/visualTest.ts
+++ b/workbench/_web/src/lib/visualTest.ts
@@ -43,9 +43,7 @@ export function maskLogitLensDataForVisualTest(data: LogitLensData): LogitLensDa
 
     // topk is indexed [layer][position]; keep only the final-prediction cell.
     const topk = data.topk.map((layerRow, layerIdx) =>
-        layerRow.map((cell, pos) =>
-            layerIdx === lastLayer && pos === lastPos ? cell : [""],
-        ),
+        layerRow.map((cell, pos) => (layerIdx === lastLayer && pos === lastPos ? cell : [""])),
     );
 
     // Flatten every tracked trajectory to a constant. The final cell reads its

--- a/workbench/_web/src/lib/visualTest.ts
+++ b/workbench/_web/src/lib/visualTest.ts
@@ -1,0 +1,82 @@
+/**
+ * Visual-test (Argos) determinism helpers.
+ *
+ * The visual regression suite runs against the real NDIF service (see
+ * `.github/workflows/e2e.yml`). Real model runs are only *approximately*
+ * reproducible: floating-point results drift run-to-run across NDIF hardware,
+ * and that drift shows up as pixel noise in the heatmap cell colors and the
+ * plotted trajectory/line curves — which makes Argos snapshots flaky even
+ * though the UI itself is correct.
+ *
+ * Rather than mock NDIF away, we keep exercising the real request/response
+ * path and only neutralize the non-deterministic *values* right before they
+ * reach the visualization widgets, when `NEXT_PUBLIC_VISUAL_TEST` is set:
+ *
+ *  - Logit-lens heatmap: blank every cell except the final prediction (the
+ *    last token of the last layer), and flatten the tracked trajectories so
+ *    that one remaining cell's color (and the layer skyline) is stable.
+ *  - Activation-patching line plot: flatten the plotted series so the drawn
+ *    lines are constant. The chart chrome (axes, mode bar, token selector)
+ *    still renders, but the noisy curves are ignored.
+ *
+ * This flag is `NEXT_PUBLIC_` so it is inlined into the client bundle at build
+ * time; it must be present when `next build` runs.
+ */
+
+import type { LogitLensData } from "nnsightful";
+import type { ActivationPatchingData } from "@/types/activationPatching";
+
+export function isVisualTestMode(): boolean {
+    return process.env.NEXT_PUBLIC_VISUAL_TEST === "true";
+}
+
+/**
+ * Blank all heatmap content except the final-prediction cell (last token of
+ * the last layer). Token text at that cell stays real so the snapshot still
+ * verifies the model's actual next-token prediction rendered; everything else
+ * — including the values that drive cell colors — is zeroed so the image is
+ * deterministic.
+ */
+export function maskLogitLensDataForVisualTest(data: LogitLensData): LogitLensData {
+    const lastLayer = data.layers.length - 1;
+    const lastPos = data.input.length - 1;
+
+    // topk is indexed [layer][position]; keep only the final-prediction cell.
+    const topk = data.topk.map((layerRow, layerIdx) =>
+        layerRow.map((cell, pos) =>
+            layerIdx === lastLayer && pos === lastPos ? cell : [""],
+        ),
+    );
+
+    // Flatten every tracked trajectory to a constant. The final cell reads its
+    // probability from here, so this pins its color; blanked cells reference
+    // tokens absent from `tracked` and render at probability 0.
+    const tracked = data.tracked.map((posMap) => {
+        const flat: Record<string, number[]> = {};
+        for (const [token, trajectory] of Object.entries(posMap)) {
+            flat[token] = trajectory.map(() => 1);
+        }
+        return flat;
+    });
+
+    const entropy = data.entropy?.map((layerRow) => layerRow.map(() => 0));
+
+    return { ...data, topk, tracked, ...(entropy ? { entropy } : {}) };
+}
+
+/**
+ * Flatten the activation-patching series so the plotted lines are constant and
+ * therefore deterministic. Layer count, token labels and chart chrome are left
+ * intact — only the curve values are ignored.
+ */
+export function maskActivationPatchingDataForVisualTest(
+    data: ActivationPatchingData,
+): ActivationPatchingData {
+    const flatten = (grid: number[][]) => grid.map((row) => row.map(() => 0));
+    return {
+        ...data,
+        lines: flatten(data.lines),
+        ranks: flatten(data.ranks),
+        prob_diffs: flatten(data.prob_diffs),
+    };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The visual regression suite (Argos) runs against the **real NDIF service** and is flaky. Real model runs are only approximately reproducible: floating-point results drift run-to-run across NDIF hardware, so even for a fixed prompt the heatmap cell colors and plotted line curves shift by a few pixels. Argos flags this noise as a diff even though the UI is correct.

We want to keep exercising the real NDIF request/response path, but stop comparing the noisy pixels.

## Approach

Add a `NEXT_PUBLIC_VISUAL_TEST` flag. When set, we neutralize just the non-deterministic **values** right before they reach the `nnsightful` widgets — the network path, polling, and widget wiring are all still exercised:

- **Logit-lens heatmap** (`Lens2Display`): blank every cell's top-k except the final prediction — the **last token of the last layer** (which the widget already treats as the final-prediction cell). The predicted token text there stays real; `tracked`/`entropy` are flattened so that cell's color and the per-layer skyline are stable. Fresh workspaces show no trajectory line-plot by default, so only the (masked) heatmap is captured.
- **Activation-patching line plot** (`ActivationPatchingDisplay`): flatten the plotted series (`lines`/`ranks`/`prob_diffs`) so the drawn curves are constant and ignored. The chart chrome (axes, mode bar, token selector, layer count, labels) still renders.

The masking is centralized in `src/lib/visualTest.ts` and gated by `isVisualTestMode()`, memoized so the widgets don't rebuild every render. Outside visual-test mode there is zero behavior change.

## Enabling it

`NEXT_PUBLIC_VISUAL_TEST` is a build-time-inlined public env var, so it's added to `.env` in the e2e workflow **before** `next build`.

## Files

- `workbench/_web/src/lib/visualTest.ts` — flag + `maskLogitLensDataForVisualTest` / `maskActivationPatchingDataForVisualTest`.
- `workbench/_web/.../lens2/[chartId]/components/Lens2Display.tsx` — apply mask to widget data.
- `workbench/_web/.../activation-patching/[chartId]/components/ActivationPatchingDisplay.tsx` — apply mask to widget data.
- `.github/workflows/e2e.yml` — set `NEXT_PUBLIC_VISUAL_TEST=true`.

## Verification

- `bunx tsc --noEmit`: no new errors from these changes (the one remaining error on the AP widget `data` prop is pre-existing — verified against the base commit — and silenced by `ignoreBuildErrors`).
- `bun run lint`: no new lint errors in the changed files.

Note: baselines will need to be re-approved once in Argos, since the rendered snapshots change (that's the intended, now-deterministic output).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76815e1d-873e-4d0d-bbf8-caa90bdf92e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76815e1d-873e-4d0d-bbf8-caa90bdf92e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

