### PR TITLE
feat(chat): cross-workbench Chat tool with Logit Lens / Patch Lens handoff

### DIFF
--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatComposer.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatComposer.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Send } from "lucide-react";
+import { MIN_MAX_NEW_TOKENS, MAX_MAX_NEW_TOKENS } from "@/stores/useChat";
+
+interface ChatComposerProps {
+    draft: string;
+    onDraftChange: (text: string) => void;
+    onSend: () => void;
+    maxNewTokens: number;
+    onMaxNewTokensChange: (n: number) => void;
+    disabled?: boolean;
+    isGenerating?: boolean;
+}
+
+/**
+ * Prompt composer for the chat rail. Submit is ⌘/Ctrl+Enter (plain Enter is a
+ * newline), matching the other prompt inputs in the app.
+ */
+export function ChatComposer({
+    draft,
+    onDraftChange,
+    onSend,
+    maxNewTokens,
+    onMaxNewTokensChange,
+    disabled = false,
+    isGenerating = false,
+}: ChatComposerProps) {
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                if (!disabled && draft.trim()) onSend();
+            }
+        },
+        [disabled, draft, onSend],
+    );
+
+    return (
+        <div className="border-t p-3 flex flex-col gap-2">
+            <Textarea
+                ref={textareaRef}
+                value={draft}
+                onChange={(e) => onDraftChange(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Message the model…"
+                aria-label="Chat prompt"
+                disabled={disabled}
+                className="w-full !text-sm bg-input/30 min-h-20 max-h-48 !leading-5 resize-none"
+            />
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                    <Label htmlFor="chat-max-tokens" className="text-xs text-muted-foreground">
+                        Tokens
+                    </Label>
+                    <Input
+                        id="chat-max-tokens"
+                        type="number"
+                        min={MIN_MAX_NEW_TOKENS}
+                        max={MAX_MAX_NEW_TOKENS}
+                        value={maxNewTokens}
+                        onChange={(e) => onMaxNewTokensChange(Number(e.target.value))}
+                        disabled={disabled}
+                        aria-label="Max new tokens"
+                        className="h-8 w-16 text-sm tabular-nums"
+                    />
+                </div>
+                <Button
+                    type="button"
+                    size="sm"
+                    onClick={onSend}
+                    disabled={disabled || !draft.trim()}
+                    className="gap-1.5"
+                >
+                    {isGenerating ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                        <Send className="h-4 w-4" />
+                    )}
+                    Send
+                </Button>
+            </div>
+            <p className="text-xs text-muted-foreground text-center">
+                <kbd className="px-1 py-0.5 bg-muted rounded text-xs">⌘</kbd> +{" "}
+                <kbd className="px-1 py-0.5 bg-muted rounded text-xs">Enter</kbd> to send
+            </p>
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatMessageItem.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatMessageItem.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Loader2, Layers, AlertCircle, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PatchLensIcon } from "@/components/PatchLensIcon";
+import { cn } from "@/lib/utils";
+import type { ChatMessage, ChatInjectTarget } from "@/stores/useChat";
+
+interface ChatMessageItemProps {
+    message: ChatMessage;
+    onSendToTool: (target: ChatInjectTarget, text: string) => void;
+    onRemove: (id: string) => void;
+}
+
+/**
+ * A single chat turn: the user's prompt followed by the model's generated
+ * continuation. The full text (prompt + continuation) can be captured back
+ * into the Logit Lens / Patch Lens tools.
+ */
+export function ChatMessageItem({ message, onSendToTool, onRemove }: ChatMessageItemProps) {
+    const { prompt, completion, status } = message;
+    // The backend returns the full completion (prompt + continuation); split it
+    // so the generated part can be visually distinguished from the input.
+    const continuation =
+        completion && completion.startsWith(prompt) ? completion.slice(prompt.length) : completion;
+    const captureText = completion || prompt;
+
+    return (
+        <div className="group rounded border bg-background/60 p-2.5 flex flex-col gap-2">
+            <div
+                className="text-sm font-mono whitespace-pre-wrap break-words leading-5"
+                aria-live="polite"
+            >
+                <span className="text-muted-foreground">{prompt}</span>
+                {status === "done" && <span className="text-foreground">{continuation}</span>}
+            </div>
+
+            {status === "pending" && (
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    Generating…
+                </div>
+            )}
+
+            {status === "error" && (
+                <div className="flex items-start gap-1.5 text-xs text-destructive">
+                    <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    <span className="break-words">{message.error || "Generation failed."}</span>
+                </div>
+            )}
+
+            <div
+                className={cn(
+                    "flex items-center gap-1",
+                    status === "done" ? "opacity-100" : "opacity-60",
+                )}
+            >
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
+                    disabled={status !== "done"}
+                    onClick={() => onSendToTool("lens2", captureText)}
+                    title="Analyze this text in the Logit Lens"
+                >
+                    <Layers className="h-3.5 w-3.5" />
+                    Logit Lens
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 px-2 text-xs gap-1 text-muted-foreground hover:text-foreground"
+                    disabled={status !== "done"}
+                    onClick={() => onSendToTool("patch-lens", captureText)}
+                    title="Send this text to Patch Lens"
+                >
+                    <PatchLensIcon className="h-3.5 w-3.5" />
+                    Patch Lens
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="ml-auto h-6 w-6 text-muted-foreground/50 hover:text-foreground"
+                    onClick={() => onRemove(message.id)}
+                    aria-label="Remove message"
+                    title="Remove message"
+                >
+                    <X className="h-3.5 w-3.5" />
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatPanel.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatPanel.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { MessageSquare, PanelRightClose, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ChatComposer } from "./ChatComposer";
+import { ChatMessageItem } from "./ChatMessageItem";
+import type { ChatController } from "./useChatController";
+
+interface ChatPanelProps {
+    controller: ChatController;
+    /** Rendered as the header collapse/close affordance (rail collapse on
+     * desktop, drawer close on mobile). Omitted → no button. */
+    onCollapse?: () => void;
+    collapseIcon?: React.ReactNode;
+    collapseLabel?: string;
+}
+
+/**
+ * The full chat surface: header, scrollable transcript, and the composer.
+ * Presentational — all state comes from the passed `controller`. Shared by the
+ * desktop rail and the mobile drawer.
+ */
+export function ChatPanel({
+    controller,
+    onCollapse,
+    collapseIcon,
+    collapseLabel = "Collapse chat",
+}: ChatPanelProps) {
+    const {
+        messages,
+        draft,
+        setDraft,
+        maxNewTokens,
+        setMaxNewTokens,
+        modelAvailable,
+        isGenerating,
+        send,
+        clear,
+        removeMessage,
+        sendToTool,
+    } = controller;
+
+    const scrollRef = useRef<HTMLDivElement>(null);
+
+    // Keep the newest turn in view as generation streams in and completes.
+    useEffect(() => {
+        const el = scrollRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [messages]);
+
+    return (
+        <div className="flex h-full flex-col min-h-0">
+            <div className="p-3 border-b flex items-center justify-between">
+                <h2 className="text-sm pl-2 font-medium flex items-center gap-2">
+                    <MessageSquare className="h-4 w-4 text-primary/70" />
+                    Chat
+                </h2>
+                <div className="flex items-center gap-1">
+                    {messages.length > 0 && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 text-muted-foreground/60 hover:text-foreground"
+                            onClick={clear}
+                            aria-label="Clear chat history"
+                            title="Clear chat history"
+                        >
+                            <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                    )}
+                    {onCollapse && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 text-muted-foreground/60 hover:text-foreground"
+                            onClick={onCollapse}
+                            aria-label={collapseLabel}
+                            title={collapseLabel}
+                        >
+                            {collapseIcon ?? <PanelRightClose className="h-3.5 w-3.5" />}
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            <div ref={scrollRef} className="flex-1 min-h-0 overflow-auto p-3 flex flex-col gap-2">
+                {messages.length === 0 ? (
+                    <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center px-4 py-8">
+                        <MessageSquare className="h-6 w-6 text-muted-foreground/40" />
+                        <p className="text-sm text-muted-foreground">
+                            Prompt the active model and generate a continuation.
+                        </p>
+                        <p className="text-xs text-muted-foreground/70">
+                            Spin a prompt out from a tool, or send a result back into the Logit
+                            Lens.
+                        </p>
+                    </div>
+                ) : (
+                    messages.map((message) => (
+                        <ChatMessageItem
+                            key={message.id}
+                            message={message}
+                            onSendToTool={sendToTool}
+                            onRemove={removeMessage}
+                        />
+                    ))
+                )}
+            </div>
+
+            {!modelAvailable && (
+                <p className="px-3 py-2 text-xs text-muted-foreground border-t bg-muted/30">
+                    Select a model in the header to start chatting.
+                </p>
+            )}
+
+            <ChatComposer
+                draft={draft}
+                onDraftChange={setDraft}
+                onSend={() => send()}
+                maxNewTokens={maxNewTokens}
+                onMaxNewTokensChange={setMaxNewTokens}
+                disabled={!modelAvailable}
+                isGenerating={isGenerating}
+            />
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatRail.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/ChatRail.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { MessageSquare, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useChat } from "@/stores/useChat";
+import { ChatPanel } from "./ChatPanel";
+import { useChatController } from "./useChatController";
+
+/**
+ * Desktop chat rail. Collapsed to a slim strip by default so it stays out of
+ * the way; expands into a full chat panel. The controller is mounted whether or
+ * not the panel is expanded, so spin-out seeds and in-flight generations keep
+ * working even while collapsed.
+ */
+export function ChatRail() {
+    const open = useChat((s) => s.open);
+    const setOpen = useChat((s) => s.setOpen);
+    const controller = useChatController();
+
+    if (!open) {
+        return (
+            <div className="h-full pb-3 pr-3 flex">
+                <div className="w-11 h-full rounded dark:bg-secondary/50 bg-secondary/80 border flex flex-col items-center py-2 gap-2">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setOpen(true)}
+                        className="h-7 w-7 hover:bg-muted"
+                        aria-label="Open chat"
+                        title="Open chat"
+                        data-testid="chat-open-button"
+                    >
+                        {controller.isGenerating ? (
+                            <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                        ) : (
+                            <MessageSquare className="h-4 w-4" />
+                        )}
+                    </Button>
+                    {controller.messages.length > 0 && !controller.isGenerating && (
+                        <span
+                            aria-hidden
+                            className="h-1.5 w-1.5 rounded-full bg-primary/60"
+                            title={`${controller.messages.length} messages`}
+                        />
+                    )}
+                    <span className="mt-1 text-xs text-muted-foreground [writing-mode:vertical-lr] rotate-180 select-none">
+                        Chat
+                    </span>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="h-full pb-3 pr-3">
+            <div
+                data-testid="chat-panel"
+                className="w-[340px] xl:w-[380px] h-full rounded dark:bg-secondary/50 bg-secondary/80 border overflow-hidden"
+            >
+                <ChatPanel controller={controller} onCollapse={() => setOpen(false)} />
+            </div>
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/MobileChatDrawer.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/MobileChatDrawer.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useParams } from "next/navigation";
+import { MessageSquare, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useChat } from "@/stores/useChat";
+import { ChatPanel } from "./ChatPanel";
+import { useChatController } from "./useChatController";
+
+function MobileChatSheet({ onClose }: { onClose: () => void }) {
+    const controller = useChatController();
+    const ref = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") onClose();
+        };
+        document.addEventListener("keydown", onKeyDown);
+        ref.current?.focus();
+        return () => document.removeEventListener("keydown", onKeyDown);
+    }, [onClose]);
+
+    return (
+        <>
+            <div
+                className="fixed inset-0 z-40 bg-black/50 animate-in fade-in duration-200"
+                onClick={onClose}
+            />
+            <div
+                ref={ref}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Chat"
+                tabIndex={-1}
+                data-testid="chat-panel"
+                className="fixed inset-y-0 right-0 z-50 w-[85vw] max-w-sm flex flex-col animate-in slide-in-from-right duration-200 shadow-2xl border-l border-border/40 bg-gradient-to-b from-card to-background outline-none"
+            >
+                <ChatPanel
+                    controller={controller}
+                    onCollapse={onClose}
+                    collapseIcon={<X className="h-3.5 w-3.5" />}
+                    collapseLabel="Close chat"
+                />
+            </div>
+        </>
+    );
+}
+
+/**
+ * Mobile chat entry point: a bottom-right FAB (mirroring the bottom-left
+ * charts drawer) that opens a right-side slide-over. Open state is shared with
+ * the desktop rail via the store so a spin-out opens whichever surface is
+ * mounted.
+ */
+export function MobileChatDrawer() {
+    const { workspaceId } = useParams<{ workspaceId: string }>();
+    const open = useChat((s) => s.open);
+    const setOpen = useChat((s) => s.setOpen);
+    const isGenerating = useChat((s) =>
+        (s.historyByWorkspace[workspaceId] ?? []).some((m) => m.status === "pending"),
+    );
+
+    return (
+        <>
+            <Button
+                variant="outline"
+                size="icon"
+                aria-label="Open chat"
+                onClick={() => setOpen(true)}
+                data-testid="chat-open-button"
+                className="fixed bottom-4 right-4 z-40 h-11 w-11 rounded-full shadow-lg bg-card border-border/60 hover:bg-accent"
+            >
+                <MessageSquare className="h-5 w-5" />
+                {isGenerating && (
+                    <span className="absolute -top-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-primary animate-pulse" />
+                )}
+            </Button>
+            {open && <MobileChatSheet onClose={() => setOpen(false)} />}
+        </>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/SpinOutButton.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/SpinOutButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { MessageSquarePlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useChat } from "@/stores/useChat";
+
+interface SpinOutButtonProps {
+    /** Resolves the current prompt text at click time. */
+    getText: () => string;
+    disabled?: boolean;
+    className?: string;
+}
+
+/**
+ * "Spin out to chat" — pushes a tool's current prompt into the chat composer
+ * and generates a continuation, so a researcher can explore how the model
+ * continues a prompt and then capture the result back into a tool.
+ */
+export function SpinOutButton({ getText, disabled = false, className }: SpinOutButtonProps) {
+    const spinOut = useChat((s) => s.spinOut);
+    return (
+        <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className={cn("h-6 px-2 text-xs gap-1 text-muted-foreground", className)}
+            disabled={disabled}
+            onClick={() => {
+                const text = getText().trim();
+                if (text) spinOut(text);
+            }}
+            aria-label="Spin prompt out to chat"
+            title="Send this prompt to the chat and generate a continuation"
+        >
+            <MessageSquarePlus className="h-3.5 w-3.5" />
+            Spin out
+        </Button>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/WorkbenchChat.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/WorkbenchChat.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { ChatRail } from "./ChatRail";
+import { MobileChatDrawer } from "./MobileChatDrawer";
+
+/**
+ * Workspace-wide layout wrapper that makes the Chat tool available on every
+ * tool page. On desktop the chat is a collapsible right rail that shares the
+ * horizontal space with the tool; on mobile it's a bottom-right FAB + drawer.
+ */
+export function WorkbenchChat({ children }: { children: ReactNode }) {
+    const isMobile = useIsMobile();
+
+    // Before the media query resolves, render children full-width to avoid a
+    // layout flash. The rail mounts once we know the viewport.
+    if (isMobile === undefined) {
+        return <div className="size-full min-h-0">{children}</div>;
+    }
+
+    if (isMobile) {
+        return (
+            <div className="size-full min-h-0">
+                {children}
+                <MobileChatDrawer />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex size-full min-h-0">
+            <div className="flex-1 min-w-0 min-h-0">{children}</div>
+            <ChatRail />
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/chat/useChatController.ts
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/chat/useChatController.ts
@@ -1,0 +1,219 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import { useWorkspace } from "@/stores/useWorkspace";
+import { useModelsQuery, generateCompletion } from "@/lib/api/modelsApi";
+import { useChat, type ChatMessage, type ChatInjectTarget } from "@/stores/useChat";
+import { useCreateLens2ChartPair, useCreatePatchLensChartPair } from "@/lib/api/chartApi";
+import type { Lens2ConfigData } from "@/types/lens2";
+
+const generateId = () =>
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `chat-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+export interface ChatController {
+    workspaceId: string;
+    messages: ChatMessage[];
+    draft: string;
+    setDraft: (text: string) => void;
+    maxNewTokens: number;
+    setMaxNewTokens: (n: number) => void;
+    /** Model completions will run against. Empty when no model is available. */
+    model: string;
+    modelAvailable: boolean;
+    /** True while any turn in this workspace is generating. */
+    isGenerating: boolean;
+    /** Send the current draft (or an explicit text) for completion. */
+    send: (text?: string) => void;
+    clear: () => void;
+    removeMessage: (id: string) => void;
+    /** Capture a message's text back into a tool (current chart if compatible,
+     * otherwise a freshly created chart). */
+    sendToTool: (target: ChatInjectTarget, text: string) => void;
+}
+
+/**
+ * Business logic for the chat rail. Owns generation, per-workspace history, the
+ * spin-out seed, and the send-to-tool handoff. Shared by the desktop rail and
+ * the mobile drawer.
+ */
+export function useChatController(): ChatController {
+    const { workspaceId } = useParams<{ workspaceId: string }>();
+    const pathname = usePathname();
+    const router = useRouter();
+
+    const { selectedModelIdx } = useWorkspace();
+    const { data: models } = useModelsQuery();
+
+    const {
+        maxNewTokens,
+        setMaxNewTokens,
+        draftByWorkspace,
+        historyByWorkspace,
+        setDraft: setDraftRaw,
+        addMessage,
+        updateMessage,
+        removeMessage: removeMessageRaw,
+        clearHistory,
+        seed,
+        consumeSeed,
+        requestInjection,
+    } = useChat();
+
+    const { mutate: createLens2 } = useCreateLens2ChartPair();
+    const { mutate: createPatchLens } = useCreatePatchLensChartPair();
+
+    const model = useMemo(() => {
+        if (!models || models.length === 0) return "";
+        return models[selectedModelIdx]?.name ?? models[0].name;
+    }, [models, selectedModelIdx]);
+    const modelAvailable = !!model;
+
+    const messages = historyByWorkspace[workspaceId] ?? [];
+    const draft = draftByWorkspace[workspaceId] ?? "";
+    const isGenerating = messages.some((m) => m.status === "pending");
+
+    const setDraft = useCallback(
+        (text: string) => setDraftRaw(workspaceId, text),
+        [setDraftRaw, workspaceId],
+    );
+
+    const removeMessage = useCallback(
+        (id: string) => removeMessageRaw(workspaceId, id),
+        [removeMessageRaw, workspaceId],
+    );
+
+    const clear = useCallback(() => clearHistory(workspaceId), [clearHistory, workspaceId]);
+
+    const send = useCallback(
+        (textArg?: string) => {
+            const text = (textArg ?? draftByWorkspace[workspaceId] ?? "").trim();
+            if (!text) return;
+            const id = generateId();
+            const turnModel = model;
+            const turnTokens = maxNewTokens;
+            addMessage(workspaceId, {
+                id,
+                prompt: text,
+                completion: "",
+                model: turnModel,
+                maxNewTokens: turnTokens,
+                status: "pending",
+                createdAt: Date.now(),
+            });
+            setDraftRaw(workspaceId, "");
+
+            if (!turnModel) {
+                updateMessage(workspaceId, id, {
+                    status: "error",
+                    error: "No model selected. Pick a model from the header, then try again.",
+                });
+                return;
+            }
+
+            generateCompletion({ prompt: text, max_new_tokens: turnTokens, model: turnModel })
+                .then((res) => {
+                    const completion = res.completion.map((tok) => tok.text).join("");
+                    updateMessage(workspaceId, id, {
+                        completion: completion || text,
+                        status: "done",
+                    });
+                })
+                .catch((err) => {
+                    updateMessage(workspaceId, id, {
+                        status: "error",
+                        error: err instanceof Error ? err.message : String(err),
+                    });
+                });
+        },
+        [
+            draftByWorkspace,
+            workspaceId,
+            model,
+            maxNewTokens,
+            addMessage,
+            updateMessage,
+            setDraftRaw,
+        ],
+    );
+
+    const sendToTool = useCallback(
+        (target: ChatInjectTarget, text: string) => {
+            const trimmed = text.trim();
+            if (!trimmed || !workspaceId) return;
+
+            const onLens2Route = !!pathname && pathname.includes(`/lens2/`);
+            const onPatchLensRoute = !!pathname && pathname.includes(`/patch-lens/`);
+
+            if (target === "lens2") {
+                if (onLens2Route) {
+                    requestInjection("lens2", trimmed);
+                    return;
+                }
+                const config: Lens2ConfigData = {
+                    prompt: trimmed,
+                    model: model || "",
+                    topk: 5,
+                    includeEntropy: true,
+                };
+                createLens2(
+                    { workspaceId, config },
+                    {
+                        onSuccess: ({ chart }) =>
+                            router.push(`/workbench/${workspaceId}/lens2/${chart.id}`),
+                    },
+                );
+                return;
+            }
+
+            // target === "patch-lens"
+            if (onPatchLensRoute) {
+                requestInjection("patch-lens", trimmed);
+                return;
+            }
+            createPatchLens(
+                { workspaceId },
+                {
+                    onSuccess: ({ chart }) => {
+                        // The new page consumes this once it mounts.
+                        requestInjection("patch-lens", trimmed);
+                        router.push(`/workbench/${workspaceId}/patch-lens/${chart.id}`);
+                    },
+                },
+            );
+        },
+        [workspaceId, pathname, model, requestInjection, createLens2, createPatchLens, router],
+    );
+
+    // Consume a spin-out seed: prefill the composer and (optionally) fire a
+    // generation immediately so the user "sees up to N tokens" without a
+    // second click. Guarded by nonce so it runs exactly once per spin-out.
+    const seedNonceRef = useRef(0);
+    useEffect(() => {
+        if (!seed || seed.nonce === seedNonceRef.current) return;
+        seedNonceRef.current = seed.nonce;
+        const text = seed.text.trim();
+        setDraftRaw(workspaceId, text);
+        const shouldRun = seed.autoRun;
+        consumeSeed();
+        if (shouldRun && text) send(text);
+    }, [seed, workspaceId, setDraftRaw, consumeSeed, send]);
+
+    return {
+        workspaceId,
+        messages,
+        draft,
+        setDraft,
+        maxNewTokens,
+        setMaxNewTokens,
+        model,
+        modelAvailable,
+        isGenerating,
+        send,
+        clear,
+        removeMessage,
+        sendToTool,
+    };
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/layout.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/layout.tsx
@@ -9,6 +9,7 @@ import { ModelControl } from "@/components/ModelControl";
 import { CaptureProvider } from "@/components/providers/CaptureProvider";
 import { Button } from "@/components/ui/button";
 import { WorkspaceNameEditor } from "@/components/WorkspaceNameEditor";
+import { WorkbenchChat } from "./components/chat/WorkbenchChat";
 
 export default function WorkbenchLayout({
     children,
@@ -91,7 +92,9 @@ export default function WorkbenchLayout({
                 </nav>
             </header>
             <main className="flex-1 min-h-0 overflow-hidden">
-                <CaptureProvider>{children}</CaptureProvider>
+                <CaptureProvider>
+                    <WorkbenchChat>{children}</WorkbenchChat>
+                </CaptureProvider>
             </main>
         </div>
     );

--- a/workbench/_web/src/app/workbench/[workspaceId]/lens2/[chartId]/components/Lens2Controls.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/lens2/[chartId]/components/Lens2Controls.tsx
@@ -21,6 +21,8 @@ import { useDraftModel } from "@/hooks/useDraftModel";
 import { useBlurTokenizeScheduler } from "@/hooks/useBlurTokenizeScheduler";
 import { useBackgroundTokenPair } from "@/hooks/useBackgroundTokenPair";
 import { ToolPanelHeader } from "@/app/workbench/[workspaceId]/components/ToolPanelHeader";
+import { SpinOutButton } from "@/app/workbench/[workspaceId]/components/chat/SpinOutButton";
+import { useChat } from "@/stores/useChat";
 
 interface Lens2Config {
     id: string;
@@ -141,6 +143,31 @@ export function Lens2Controls({
             lastSyncedPromptRef.current = configPrompt;
         }
     }, [initialConfig.data?.prompt]);
+
+    // Chat handoff: a "Send to Logit Lens" from the chat rail drops its captured
+    // text into the editor here. We only load it into the draft (not the saved
+    // config) and open the editor so the user can review/run — the auto-run
+    // path is gated on the saved prompt, so this won't fire a run on its own.
+    const injection = useChat((s) => s.injection);
+    const consumeInjection = useChat((s) => s.consumeInjection);
+    const injectionNonceRef = useRef(0);
+    useEffect(() => {
+        if (!injection || injection.target !== "lens2") return;
+        if (injection.nonce === injectionNonceRef.current) return;
+        injectionNonceRef.current = injection.nonce;
+        const text = injection.text;
+        setPrompt(text);
+        setEditingText(true);
+        lastSyncedPromptRef.current = text;
+        consumeInjection();
+        setTimeout(() => {
+            const el = textareaRef.current;
+            if (el) {
+                el.focus();
+                el.setSelectionRange(el.value.length, el.value.length);
+            }
+        }, 0);
+    }, [injection, consumeInjection]);
 
     // Auto-retokenize on selected-model change when the chart has no data
     // yet. During initial composition the user has no committed visualization
@@ -522,7 +549,13 @@ export function Lens2Controls({
             />
             <div className="p-3 flex-1 overflow-auto flex flex-col gap-4">
                 <div className="flex flex-col gap-2">
-                    <Label className="text-sm font-medium">Prompt</Label>
+                    <div className="flex items-center justify-between">
+                        <Label className="text-sm font-medium">Prompt</Label>
+                        <SpinOutButton
+                            getText={() => prompt}
+                            disabled={!prompt.trim() || isExecuting}
+                        />
+                    </div>
                     <div className="relative">
                         {editingText ? (
                             <Textarea

--- a/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/PatchLensArea.tsx
@@ -20,6 +20,7 @@ import { usePatchLensLogitLens, PatchLensResult } from "@/lib/api/patchLensApi";
 import { finalPrediction } from "@/lib/lens-last-row";
 import type { NormalizedRun } from "@/lib/lensRun";
 import { LensHistoryRail } from "./LensHistoryRail";
+import { SpinOutButton } from "@/app/workbench/[workspaceId]/components/chat/SpinOutButton";
 
 // Default model for the CM intro. 32 layers reads as a manageable heatmap;
 // index 0 in the model list is the 70B (80 layers), far too many for a primer.
@@ -391,6 +392,10 @@ export default function PatchLensArea({
                             </TooltipContent>
                         </Tooltip>
                     )}
+                    <SpinOutButton
+                        getText={() => sourcePrompt}
+                        disabled={!sourcePrompt.trim() || isRunning}
+                    />
                     <Button
                         variant="ghost"
                         size="sm"

--- a/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/page.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/page.tsx
@@ -19,6 +19,7 @@ import { getLensRunHeatmapsByIds } from "@/lib/queries/lensRunQueries";
 import { queryKeys } from "@/lib/queryKeys";
 import type { PatchLensChartData } from "@/types/patchLens";
 import type { NormalizedRun } from "@/lib/lensRun";
+import { useChat } from "@/stores/useChat";
 
 const PROMPT_AUTOSAVE_DEBOUNCE_MS = 600;
 
@@ -163,6 +164,20 @@ export default function PatchLensChartPage() {
         }, PROMPT_AUTOSAVE_DEBOUNCE_MS);
         return () => clearTimeout(handle);
     }, [sourcePrompt, targetPrompt, chartId, queryClient]);
+
+    // Chat handoff: a "Send to Patch Lens" from the chat rail loads its captured
+    // text into the source prompt and re-tokenizes it (via restoreNonce).
+    const injection = useChat((s) => s.injection);
+    const consumeInjection = useChat((s) => s.consumeInjection);
+    const injectionNonceRef = useRef(0);
+    useEffect(() => {
+        if (!injection || injection.target !== "patch-lens") return;
+        if (injection.nonce === injectionNonceRef.current) return;
+        injectionNonceRef.current = injection.nonce;
+        setSourcePrompt(injection.text);
+        setRestoreNonce((n) => n + 1);
+        consumeInjection();
+    }, [injection, consumeInjection]);
 
     if (isMobile === undefined) return null;
 

--- a/workbench/_web/src/lib/api/modelsApi.ts
+++ b/workbench/_web/src/lib/api/modelsApi.ts
@@ -36,7 +36,7 @@ export const usePrediction = () => {
     });
 };
 
-interface Completion {
+interface GenerationRequest {
     prompt: string;
     max_new_tokens: number;
     model: string;
@@ -47,7 +47,18 @@ export interface GenerationResponse {
     last_token_prediction: Prediction;
 }
 
-const generate = async (request: Completion): Promise<GenerationResponse> => {
+/**
+ * Bare generation call (no toast). Runs a completion of `max_new_tokens` on the
+ * given model and resolves the two-step NDIF start→poll→results flow into a
+ * single promise.
+ *
+ * Exported so features that render their own inline error UI (the chat rail)
+ * can call it without the `useGenerate` toast — same convention as the other
+ * tool APIs (see CLAUDE.md §7).
+ */
+export const generateCompletion = async (
+    request: GenerationRequest,
+): Promise<GenerationResponse> => {
     const headers = await createUserHeadersAction();
     return await startAndPoll<GenerationResponse>(
         config.endpoints.startGenerate,
@@ -59,7 +70,7 @@ const generate = async (request: Completion): Promise<GenerationResponse> => {
 
 export const useGenerate = () => {
     return useMutation({
-        mutationFn: generate,
+        mutationFn: generateCompletion,
         onError: (error, variables, context) => {
             toast.error(`Error: ${error}`);
         },

--- a/workbench/_web/src/stores/useChat.ts
+++ b/workbench/_web/src/stores/useChat.ts
@@ -1,0 +1,199 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+
+/**
+ * Cross-workbench "Chat" tool state.
+ *
+ * The chat is a lightweight completion playground wired to the same model the
+ * rest of the workspace uses. It lives in a collapsible rail so it stays
+ * unobtrusive when idle, and it can hand prompts back and forth with the
+ * interpretability tools:
+ *   - "spin out"  — a tool pushes its prompt into the composer (see `seed`).
+ *   - "send to …" — a completed message pushes its text back into a tool
+ *                    (see `injection`).
+ *
+ * Durable history is kept per-workspace in localStorage (the interim approach
+ * documented in CLAUDE.md — a DB-backed `generations` table is the eventual
+ * home). `seed` and `injection` are ephemeral handoff channels and are never
+ * persisted.
+ */
+
+export type ChatInjectTarget = "lens2" | "patch-lens";
+
+export interface ChatMessage {
+    id: string;
+    /** The input text sent to the model for this turn. */
+    prompt: string;
+    /** The model's completion text (prompt + generated continuation). Empty
+     * until the generation resolves. */
+    completion: string;
+    /** Model the turn was generated with. */
+    model: string;
+    /** Tokens requested for this turn. */
+    maxNewTokens: number;
+    status: "pending" | "done" | "error";
+    error?: string;
+    createdAt: number;
+}
+
+interface SeedRequest {
+    text: string;
+    /** When true the controller should immediately generate a continuation
+     * (the "spin out to see up to N tokens" flow). */
+    autoRun: boolean;
+    nonce: number;
+}
+
+interface InjectionRequest {
+    target: ChatInjectTarget;
+    text: string;
+    nonce: number;
+}
+
+interface ChatState {
+    /** Desktop rail expanded / mobile drawer open. */
+    open: boolean;
+    /** Tokens to generate per turn. */
+    maxNewTokens: number;
+    /** Per-workspace composer draft. */
+    draftByWorkspace: Record<string, string>;
+    /** Per-workspace conversation history (oldest first). */
+    historyByWorkspace: Record<string, ChatMessage[]>;
+    /** Ephemeral: a prompt spun out from a tool into the composer. */
+    seed: SeedRequest | null;
+    /** Ephemeral: a captured prompt to inject back into a tool. */
+    injection: InjectionRequest | null;
+    /** True once persisted state has been read from localStorage. */
+    _hasHydrated: boolean;
+
+    setOpen: (open: boolean) => void;
+    toggleOpen: () => void;
+    setMaxNewTokens: (n: number) => void;
+    setDraft: (workspaceId: string, text: string) => void;
+    addMessage: (workspaceId: string, message: ChatMessage) => void;
+    updateMessage: (workspaceId: string, id: string, patch: Partial<ChatMessage>) => void;
+    removeMessage: (workspaceId: string, id: string) => void;
+    clearHistory: (workspaceId: string) => void;
+    spinOut: (text: string) => void;
+    consumeSeed: () => void;
+    requestInjection: (target: ChatInjectTarget, text: string) => void;
+    consumeInjection: () => void;
+    _setHasHydrated: (v: boolean) => void;
+}
+
+const DEFAULT_MAX_NEW_TOKENS = 20;
+export const MIN_MAX_NEW_TOKENS = 1;
+export const MAX_MAX_NEW_TOKENS = 64;
+/** Cap per-workspace history so localStorage doesn't grow without bound. */
+const MAX_HISTORY_PER_WORKSPACE = 50;
+
+const clampTokens = (n: number) =>
+    Math.max(MIN_MAX_NEW_TOKENS, Math.min(MAX_MAX_NEW_TOKENS, Math.round(n)));
+
+export const useChat = create<ChatState>()(
+    persist(
+        (set, get) => ({
+            open: false,
+            maxNewTokens: DEFAULT_MAX_NEW_TOKENS,
+            draftByWorkspace: {},
+            historyByWorkspace: {},
+            seed: null,
+            injection: null,
+            _hasHydrated: false,
+
+            setOpen: (open) => set({ open }),
+            toggleOpen: () => set({ open: !get().open }),
+            setMaxNewTokens: (n) => set({ maxNewTokens: clampTokens(n) }),
+
+            setDraft: (workspaceId, text) =>
+                set((s) => ({
+                    draftByWorkspace: { ...s.draftByWorkspace, [workspaceId]: text },
+                })),
+
+            addMessage: (workspaceId, message) =>
+                set((s) => {
+                    const existing = s.historyByWorkspace[workspaceId] ?? [];
+                    const next = [...existing, message].slice(-MAX_HISTORY_PER_WORKSPACE);
+                    return {
+                        historyByWorkspace: { ...s.historyByWorkspace, [workspaceId]: next },
+                    };
+                }),
+
+            updateMessage: (workspaceId, id, patch) =>
+                set((s) => {
+                    const existing = s.historyByWorkspace[workspaceId];
+                    if (!existing) return {};
+                    return {
+                        historyByWorkspace: {
+                            ...s.historyByWorkspace,
+                            [workspaceId]: existing.map((m) =>
+                                m.id === id ? { ...m, ...patch } : m,
+                            ),
+                        },
+                    };
+                }),
+
+            removeMessage: (workspaceId, id) =>
+                set((s) => {
+                    const existing = s.historyByWorkspace[workspaceId];
+                    if (!existing) return {};
+                    return {
+                        historyByWorkspace: {
+                            ...s.historyByWorkspace,
+                            [workspaceId]: existing.filter((m) => m.id !== id),
+                        },
+                    };
+                }),
+
+            clearHistory: (workspaceId) =>
+                set((s) => ({
+                    historyByWorkspace: { ...s.historyByWorkspace, [workspaceId]: [] },
+                })),
+
+            spinOut: (text) =>
+                set((s) => ({
+                    open: true,
+                    seed: { text, autoRun: true, nonce: (s.seed?.nonce ?? 0) + 1 },
+                })),
+
+            consumeSeed: () => set({ seed: null }),
+
+            requestInjection: (target, text) =>
+                set((s) => ({
+                    injection: { target, text, nonce: (s.injection?.nonce ?? 0) + 1 },
+                })),
+
+            consumeInjection: () => set({ injection: null }),
+
+            _setHasHydrated: (v) => set({ _hasHydrated: v }),
+        }),
+        {
+            name: "workbench:chat",
+            storage: createJSONStorage(() => localStorage),
+            // Persist durable UI + history only. Ephemeral handoff channels
+            // (seed/injection) and the hydration flag are never written.
+            partialize: (s) => ({
+                open: s.open,
+                maxNewTokens: s.maxNewTokens,
+                draftByWorkspace: s.draftByWorkspace,
+                historyByWorkspace: s.historyByWorkspace,
+            }),
+            onRehydrateStorage: () => (state) => {
+                if (!state) return;
+                // Any message left "pending" was interrupted by a reload/closed
+                // tab — the generation can never resolve, so surface it as an
+                // error instead of a spinner that hangs forever.
+                const cleaned: Record<string, ChatMessage[]> = {};
+                for (const [ws, msgs] of Object.entries(state.historyByWorkspace ?? {})) {
+                    cleaned[ws] = msgs.map((m) =>
+                        m.status === "pending"
+                            ? { ...m, status: "error" as const, error: "Interrupted" }
+                            : m,
+                    );
+                }
+                state.historyByWorkspace = cleaned;
+                state._setHasHydrated(true);
+            },
+        },
+    ),
+);

--- a/workbench/_web/tests/chat-handoff.spec.ts
+++ b/workbench/_web/tests/chat-handoff.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import { waitForModelsLoaded, gotoFreshLensWorkspace } from "./fixtures";
+
+/**
+ * Chat tool E2E that don't need NDIF — they exercise the cross-workbench chat
+ * surface and the "send a captured prompt back into a tool" handoff purely on
+ * the front end:
+ *
+ *   - The chat rail is collapsed (unobtrusive) by default and toggles open.
+ *   - A completed chat message can be sent into the Logit Lens: its text lands
+ *     in the lens prompt editor.
+ *
+ * The handoff test seeds a fixed lens2 chart (tests/seed-chat.cjs) and injects
+ * a completed chat message into localStorage so no generation is required.
+ */
+
+const WS_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const CHART_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const CHAT_URL = `/workbench/${WS_ID}/lens2/${CHART_ID}`;
+
+const CAPTURED = "The capital of France is Paris";
+
+function seedChatStorage(page: Page) {
+    return page.addInitScript(
+        ({ ws, captured }) => {
+            localStorage.setItem(
+                "workbench:chat",
+                JSON.stringify({
+                    state: {
+                        open: true,
+                        maxNewTokens: 20,
+                        draftByWorkspace: {},
+                        historyByWorkspace: {
+                            [ws]: [
+                                {
+                                    id: "seed-msg-1",
+                                    prompt: "The capital of France is",
+                                    completion: captured,
+                                    model: "openai-community/gpt2",
+                                    maxNewTokens: 20,
+                                    status: "done",
+                                    createdAt: 1,
+                                },
+                            ],
+                        },
+                    },
+                    version: 0,
+                }),
+            );
+        },
+        { ws: WS_ID, captured: CAPTURED },
+    );
+}
+
+test.describe("Chat tool (no NDIF)", () => {
+    test("rail is collapsed by default and toggles open", async ({ page }) => {
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await gotoFreshLensWorkspace(page);
+
+        // Unobtrusive when idle: only the slim open affordance is present.
+        const openButton = page.getByTestId("chat-open-button");
+        await expect(openButton).toBeVisible({ timeout: 15_000 });
+        await expect(page.getByTestId("chat-panel")).toHaveCount(0);
+
+        // Expands into the full panel with a composer.
+        await openButton.click();
+        const panel = page.getByTestId("chat-panel");
+        await expect(panel).toBeVisible();
+        await expect(panel.getByPlaceholder(/Message the model/i)).toBeVisible();
+
+        // And collapses again.
+        await panel.getByRole("button", { name: /Collapse chat/i }).click();
+        await expect(page.getByTestId("chat-panel")).toHaveCount(0);
+    });
+
+    test("send a chat result into the Logit Lens fills the prompt editor", async ({ page }) => {
+        // Seed the chart in the DB and the completed message in localStorage.
+        execFileSync("node", ["tests/seed-chat.cjs"], { stdio: "inherit" });
+
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await seedChatStorage(page);
+        await page.goto(CHAT_URL);
+        await waitForModelsLoaded(page);
+
+        // The seeded (open) panel shows the completed message.
+        const panel = page.getByTestId("chat-panel");
+        await expect(panel).toBeVisible({ timeout: 15_000 });
+        await expect(panel.getByText(CAPTURED)).toBeVisible();
+
+        // Capture it back into the Logit Lens.
+        await panel.getByRole("button", { name: "Logit Lens" }).click();
+
+        // The lens prompt editor now holds the captured text.
+        const textarea = page.getByPlaceholder(/Enter your prompt here/);
+        await expect(textarea).toBeVisible({ timeout: 15_000 });
+        await expect(textarea).toHaveValue(CAPTURED);
+    });
+});

--- a/workbench/_web/tests/chat.spec.ts
+++ b/workbench/_web/tests/chat.spec.ts
@@ -1,0 +1,74 @@
+import {
+    test,
+    expect,
+    argosScreenshot,
+    gotoFreshLensWorkspace,
+    REAL_NDIF_TIMEOUT_MS,
+} from "./fixtures";
+
+const PROMPT = "The Eiffel Tower is in the city of";
+
+/**
+ * Chat tool against real NDIF. Covers the two model-touching flows:
+ *   - typing a prompt in the chat composer and generating a continuation;
+ *   - "spinning out" the Logit Lens prompt into the chat, generating, then
+ *     capturing the result back into the lens prompt editor.
+ */
+test.describe("Chat tool (real NDIF)", () => {
+    test.setTimeout(REAL_NDIF_TIMEOUT_MS * 4);
+
+    test("compose a prompt and generate a continuation", async ({ workbenchPage: page }) => {
+        await gotoFreshLensWorkspace(page);
+
+        await page.getByTestId("chat-open-button").click();
+        const panel = page.getByTestId("chat-panel");
+        await expect(panel).toBeVisible();
+
+        // Keep the turn short so the real job round-trips quickly.
+        await panel.getByLabel(/Max new tokens/i).fill("8");
+        await panel.getByPlaceholder(/Message the model/i).fill(PROMPT);
+        await panel.getByRole("button", { name: /^Send$/ }).click();
+
+        // The turn appears immediately as pending, then resolves.
+        await expect(panel.getByText(PROMPT).first()).toBeVisible();
+        await expect(panel.getByText(/Generating/i)).toHaveCount(0, {
+            timeout: REAL_NDIF_TIMEOUT_MS,
+        });
+
+        // Once done the capture-back actions are enabled.
+        await expect(panel.getByRole("button", { name: "Logit Lens" }).first()).toBeEnabled();
+
+        await argosScreenshot(page, "chat-generation", { fullPage: false });
+    });
+
+    test("spin the lens prompt out to chat, then capture it back", async ({
+        workbenchPage: page,
+    }) => {
+        await gotoFreshLensWorkspace(page);
+
+        const textarea = page.getByPlaceholder(/Enter your prompt here/);
+        await expect(textarea).toBeVisible({ timeout: 15_000 });
+        await textarea.fill(PROMPT);
+
+        // Spin out: opens chat and auto-generates a continuation.
+        await page.getByRole("button", { name: /Spin out/i }).click();
+
+        const panel = page.getByTestId("chat-panel");
+        await expect(panel).toBeVisible();
+        await expect(panel.getByText(PROMPT).first()).toBeVisible();
+        await expect(panel.getByText(/Generating/i)).toHaveCount(0, {
+            timeout: REAL_NDIF_TIMEOUT_MS,
+        });
+
+        // Capture the (now longer) generated text back into the lens editor.
+        await panel.getByRole("button", { name: "Logit Lens" }).first().click();
+        await expect(textarea).toBeVisible();
+        // The captured text starts with the original prompt and is at least as
+        // long (prompt + generated continuation).
+        const value = await textarea.inputValue();
+        expect(value.startsWith(PROMPT)).toBeTruthy();
+        expect(value.length).toBeGreaterThanOrEqual(PROMPT.length);
+
+        await argosScreenshot(page, "chat-spin-out", { fullPage: false });
+    });
+});

--- a/workbench/_web/tests/seed-chat.cjs
+++ b/workbench/_web/tests/seed-chat.cjs
@@ -1,0 +1,55 @@
+/**
+ * Seeds the E2E SQLite DB with a deterministic Logit Lens (lens2) chart so the
+ * chat handoff spec can exercise the "send a chat result back into the Logit
+ * Lens" flow WITHOUT a model run / NDIF.
+ *
+ *   node tests/seed-chat.cjs
+ *
+ * The chart is created with an EMPTY prompt on a hot model (gpt2) so the page
+ * renders the editable controls immediately and never auto-runs a lens job —
+ * the handoff then drops captured chat text straight into the prompt editor.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require("dotenv").config();
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Database = require("better-sqlite3");
+
+const DB_PATH = process.env.LOCAL_SQLITE_URL || "./local.db";
+
+const WS_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const CHART_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const CONFIG_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const LINK_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const MODEL = "openai-community/gpt2";
+
+const configData = { prompt: "", model: MODEL, topk: 5, includeEntropy: true };
+
+const db = new Database(DB_PATH);
+const now = Date.now();
+
+db.prepare("DELETE FROM chart_config_links WHERE chart_id = ?").run(CHART_ID);
+db.prepare("DELETE FROM configs WHERE id = ?").run(CONFIG_ID);
+db.prepare("DELETE FROM charts WHERE id = ?").run(CHART_ID);
+db.prepare("DELETE FROM workspaces WHERE id = ?").run(WS_ID);
+
+db.prepare(
+    "INSERT INTO workspaces (id, user_id, name, public, updated_at) VALUES (?, ?, ?, ?, ?)",
+).run(WS_ID, "dev@localhost", "E2E Chat", 0, now);
+
+// data = null so hasData is false and no lens result renders (no NDIF needed).
+db.prepare(
+    "INSERT INTO charts (id, workspace_id, name, data, type, position, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+).run(CHART_ID, WS_ID, "Chat Handoff", null, "lens2", 0, now, now);
+
+db.prepare(
+    "INSERT INTO configs (id, workspace_id, data, type, created_at) VALUES (?, ?, ?, ?, ?)",
+).run(CONFIG_ID, WS_ID, JSON.stringify(configData), "lens2", now);
+
+db.prepare("INSERT INTO chart_config_links (id, chart_id, config_id) VALUES (?, ?, ?)").run(
+    LINK_ID,
+    CHART_ID,
+    CONFIG_ID,
+);
+
+console.log(`Seeded workspace ${WS_ID}, lens2 chart ${CHART_ID} -> ${DB_PATH}`);
+db.close();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Chat tool** available across the whole workbench — a lightweight completion playground wired to the same model the rest of the workspace uses, with easy two-way handoff to the interpretability tools.

It fulfils the request:
- **Chatbot interface to the same model**, reachable from any tool page.
- **Easy access from Logit Lens / Patch Lens** via a "Spin out" action.
- **Spin a prompt out to see up to N tokens** — pushes the current tool prompt into the chat and generates a continuation.
- **Capture a prompt back into Logit Lens (or Patch Lens)** — a completed chat result can be sent straight into a tool's prompt editor.
- **Unobtrusive when not in use** — collapsed to a slim right-edge strip by default on desktop; a bottom-right FAB + drawer on mobile.
- **E2E test coverage**.

## UX

- **Desktop**: a collapsible right rail that shares horizontal space with the active tool. Collapsed → a thin `Chat` strip with an open button; expanded → header, transcript, and composer. Mounted at the workspace layout level so it appears on every tool page.
- **Mobile**: a bottom-right `MessageSquare` FAB (mirrors the bottom-left charts drawer) opening a right-side slide-over with the same panel.
- **Composer**: multi-line prompt, a max-new-tokens field (1–64), and ⌘/Ctrl+Enter to send (plain Enter is a newline), matching the app's other prompt inputs.
- **Each turn** shows the prompt + generated continuation, with inline pending/error states and `Logit Lens` / `Patch Lens` capture actions.

## Handoff model

- **Spin out** (`SpinOutButton` in Logit Lens and Patch Lens): opens the chat, seeds the composer with the tool's prompt, and auto-generates a continuation.
- **Capture back**: a completed message can be sent to a tool. If the current route is a compatible tool it injects into that chart's prompt editor; otherwise it creates a new chart and navigates to it.
- Seed (tool → chat) and injection (chat → tool) are ephemeral channels in the store; the consuming components guard on a nonce so each handoff runs exactly once.

## Implementation

- Reuses the existing `/models/start-generate` NDIF flow — no backend changes. `modelsApi.ts` now exports a bare `generateCompletion` (no toast) for the rail's inline error UI, keeping `useGenerate` intact.
- New `useChat` zustand store (persisted to `localStorage`, keyed per-workspace) holds rail open-state, composer drafts, and conversation history. Interrupted `pending` turns are surfaced as errors on rehydrate. This is the interim history home documented in `CLAUDE.md` (a DB-backed table is the eventual target).
- New feature-local components under `app/workbench/[workspaceId]/components/chat/`: `WorkbenchChat` (layout switch), `ChatRail`, `MobileChatDrawer`, `ChatPanel`, `ChatComposer`, `ChatMessageItem`, `SpinOutButton`, and the `useChatController` hook (generation + handoff logic shared by desktop/mobile).
- Minimal edits to `layout.tsx`, `Lens2Controls.tsx`, and the Patch Lens page/area to mount the rail and wire spin-out + injection.

## Tests

- `tests/chat-handoff.spec.ts` (no NDIF): rail is collapsed by default and toggles open; a seeded completed message is captured into the Logit Lens prompt editor (seeded lens2 chart via `tests/seed-chat.cjs` + seeded chat `localStorage`, so no model run is needed).
- `tests/chat.spec.ts` (real NDIF): compose a prompt and generate a continuation; spin the lens prompt out to chat, generate, and capture the result back.

## Verification

`bunx tsc --noEmit` (no new errors), `eslint`, `knip`, `prettier --check`, and `next build` all pass for the changed files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f95503d0-5416-422a-ae67-46cdfacf2643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f95503d0-5416-422a-ae67-46cdfacf2643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

