### PR TITLE
ci(preview): give web+api pods CPU headroom, longer probe timeouts

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -306,7 +306,7 @@ jobs:
             --set ingress.host="${HOST}" \
             --set ingress.className="${INGRESS_CLASS}" \
             --atomic --cleanup-on-fail \
-            --wait --timeout 10m
+            --wait --timeout 20m
 
       - name: Write job summary
         run: |

--- a/deploy/preview/templates/deployment-api.yaml
+++ b/deploy/preview/templates/deployment-api.yaml
@@ -38,15 +38,21 @@ spec:
                 # secretName; an empty value would produce a Pod that
                 # crash-loops on missing env vars.
                 name: {{ required "api.secretName is required when api.enabled=true" .Values.api.secretName }}
+          # FastAPI's /docs handler imports the router modules on first
+          # hit; on a contended shared node the default 1s probe
+          # timeout can trip while imports finish. Match the web pod's
+          # 5s probe budget.
           readinessProbe:
             httpGet: { path: /docs, port: http }
-            initialDelaySeconds: 15
+            initialDelaySeconds: 20
             periodSeconds: 5
-            failureThreshold: 12
+            timeoutSeconds: 5
+            failureThreshold: 24
           livenessProbe:
             httpGet: { path: /docs, port: http }
             initialDelaySeconds: 60
             periodSeconds: 30
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
 {{- end }}

--- a/deploy/preview/templates/deployment.yaml
+++ b/deploy/preview/templates/deployment.yaml
@@ -45,18 +45,26 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          # Next.js prod cold start SSRs `/` on the first probe hit; on a
+          # busy shared node that render can take several seconds, so
+          # the default 1s probe timeout was tripping and kubelet was
+          # killing the container mid-startup. Give both probes a 5s
+          # timeout, and pad initialDelay so we don't sample during the
+          # first slow render.
           readinessProbe:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 10
+            initialDelaySeconds: 20
             periodSeconds: 10
-            failureThreshold: 6
+            timeoutSeconds: 5
+            failureThreshold: 12
           livenessProbe:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 30
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/preview/values.yaml
+++ b/deploy/preview/values.yaml
@@ -35,9 +35,14 @@ ingress:
     enabled: true
     host: auth.ndif-preview.ripley.cloud
 
+# CPU request == limit (Guaranteed QoS) so a preview isn't left waiting
+# on the burst pool when a shared node is contended. Next.js's first
+# render after a cold start (SSR + hydrate for /workbench/[…]/[…])
+# spikes to ~1 CPU for a few seconds; being throttled during that spike
+# is what made readiness probes time out on PR 125.
 resources:
   requests:
-    cpu: 100m
+    cpu: 1000m
     memory: 256Mi
   limits:
     cpu: 1000m
@@ -64,9 +69,12 @@ api:
     targetPort: 8000
   host: ""                        # set by workflow, e.g. pr-123-api.ndif-preview.ripley.cloud
   replicaCount: 1
+  # CPU request == limit (Guaranteed QoS); same rationale as the web
+  # pod. Uvicorn+nnsight startup imports transformers/torch on first
+  # request, which is CPU-heavy for a couple of seconds.
   resources:
-    requests: { cpu: 200m, memory: 1Gi }
-    limits:   { cpu: "2",  memory: 4Gi }
+    requests: { cpu: "2", memory: 1Gi }
+    limits:   { cpu: "2", memory: 4Gi }
   env:
     # dev.toml points remote=true at api.ndif.us — model inference runs on
     # the real NDIF backend, not in-cluster.


### PR DESCRIPTION
## Summary

PR 125's preview deploy timed out ([run 28806416400](https://github.com/ndif-team/workbench/actions/runs/28806416400)) with `helm upgrade` hitting its 10-min `--timeout` while the web pod's readiness and liveness probes kept failing with `context deadline exceeded`. The GHCR cache was healthy (~28 MB/s to clients, idle CPU) — the failure was on the target node (a busy shared worker) where:

- Containerd unpack of the 422 MB web layer took ~5 min under I/O contention from other workloads on the same node.
- Once running, Next.js's first-hit SSR of `/` spiked past the pod's 1000m CPU limit while the burst pool was contended, so probes fired against a throttled container and their default 1s timeout tripped.
- kubelet killed the container mid-startup; the replacement pod became healthy 2–3 min later, but helm had already given up.

Design intent (per Jon) is that shared nodes stay shared — no per-workload node isolation. So the fix is chart-side headroom.

## Changes

- **Web pod resources**: `cpu.request 100m → 1000m` (== `limit` → Guaranteed QoS class). Preview no longer waits on the burst pool during first render.
- **API pod resources**: `cpu.request 200m → 2` (== `limit` → Guaranteed QoS class). Uvicorn+FastAPI does its module imports on first `/docs` hit and can peg a CPU briefly.
- **Probes** (both pods): `timeoutSeconds: 1 → 5`, `initialDelaySeconds` bumped, `failureThreshold` bumped. Slow-but-eventually-healthy pods survive.
- **Helm `--timeout`**: `10m → 20m`. Cheap headroom for cold-cache unpacks.

Nothing memory-side changed (limits already at 1Gi/4Gi for web/api).

## Test plan

- [ ] After merge, PR 125's next push (or a manual rerun) deploys cleanly within the new 20 min budget.
- [ ] Verify pods land in Guaranteed QoS class: `kubectl -n workbench-preview-pr-<N> get pod -o jsonpath='{.items[*].status.qosClass}'` → `Guaranteed Guaranteed`.
- [ ] Probe timeouts visible via `kubectl -n workbench-preview-pr-<N> get pod -o yaml | grep -A2 -E 'readinessProbe|livenessProbe'`.
- [ ] Confirm the extra CPU reservation doesn't push node allocatable over the edge — 3 CPU per preview × ~5 concurrent PRs = 15 CPU reserved cluster-wide, well within capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview deployment reliability by giving services more time to start and pass health checks.
  * Extended readiness and liveness check timings to reduce false failures during slow startup.
  * Increased preview workload CPU requests to better match peak startup needs and avoid resource-related delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->