### PR TITLE
Patch Lens: always show all token rows (drop token-step control)

### DIFF
--- a/workbench/_web/bun.lock
+++ b/workbench/_web/bun.lock
@@ -35,7 +35,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#38d582a",
+        "edulogitlens": "github:jon-bell/edulogitlens#ee9e098",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",
@@ -1100,7 +1100,7 @@
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
-    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#38d582a", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-38d582a", "sha512-scafsTvOezDAjBsr2HB6GNO3xcHrGmdEz5jjmaX/+BXwECprscg9R8WlvXxJ0i+m7MydbBOEPAyWzIi8spjb+g=="],
+    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#ee9e098", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-ee9e098", "sha512-OwI6Jc8uVHiZAsIs5PF4lEKTc7NjEnYz/wpWMBNY/nCqOCHC65lELv96UXADJqEbdSDa4oQFYy6kEkYA6oi0ow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.200", "", {}, "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="],
 

--- a/workbench/_web/bun.lock
+++ b/workbench/_web/bun.lock
@@ -35,7 +35,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#ee9e098",
+        "edulogitlens": "github:jon-bell/edulogitlens#d79ec8b",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",
@@ -1100,7 +1100,7 @@
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
-    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#ee9e098", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-ee9e098", "sha512-OwI6Jc8uVHiZAsIs5PF4lEKTc7NjEnYz/wpWMBNY/nCqOCHC65lELv96UXADJqEbdSDa4oQFYy6kEkYA6oi0ow=="],
+    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#d79ec8b", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-d79ec8b", "sha512-19nH6AXe0D68jStYF5lyiZd6u7i4SmKjX5xTDP1fHQeAWIyDUyEs42L1iNjgQB61V6y5IKOPkCewer3dhvhFNg=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.200", "", {}, "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="],
 

--- a/workbench/_web/package.json
+++ b/workbench/_web/package.json
@@ -46,7 +46,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#ee9e098",
+        "edulogitlens": "github:jon-bell/edulogitlens#d79ec8b",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",

--- a/workbench/_web/package.json
+++ b/workbench/_web/package.json
@@ -46,7 +46,7 @@
         "d3-delaunay": "^6.0.4",
         "dotenv": "^17.2.1",
         "drizzle-orm": "^0.44.4",
-        "edulogitlens": "github:jon-bell/edulogitlens#38d582a",
+        "edulogitlens": "github:jon-bell/edulogitlens#ee9e098",
         "framer-motion": "^12.23.22",
         "html-to-image": "^1.11.13",
         "lexical": "^0.34.0",

--- a/workbench/_web/src/tutorials/patchLens.ts
+++ b/workbench/_web/src/tutorials/patchLens.ts
@@ -34,7 +34,7 @@ const ReadingTheLensSteps: ExtendedStepType[] = [
     {
         selector: "#patch-lens-display",
         content:
-            "Reading the heatmap: each row is a token position in your prompt (a ␣ marks a space that is part of a token), and each column is a layer. Each cell shows the model's top guess at that point — darker fill means higher probability.\n\nLarge models get downsampled to fit: amber bands mark hidden rows or columns, and the axis labels show the current step. Click an amber band to expand what it hides.",
+            "Reading the heatmap: each row is a token position in your prompt (a ␣ marks a space that is part of a token), and each column is a layer. Each cell shows the model's top guess at that point — darker fill means higher probability.\n\nEvery token row is shown. Wide models downsample layers to fit: amber bands mark hidden layers, and the axis label shows the layer step. Click an amber band to expand the hidden layers.",
         // The display mounts asynchronously (skeleton → widget) and grows as cells
         // animate in; without these reactour would size the highlight against a
         // missing/half-rendered element. The observers recompute on mount + resize.

--- a/workbench/_web/tests/patch-lens-features.spec.ts
+++ b/workbench/_web/tests/patch-lens-features.spec.ts
@@ -54,13 +54,12 @@ const reseedHistoryChart = () => {
     execFileSync("node", ["tests/seed-patch-lens.cjs", "--history-only"], { stdio: "inherit" });
 };
 
-/** Pin the shared toolbar steps so the grid density (and Argos screenshots)
- *  don't depend on the autofit's viewport-derived downsampling. The toolbar
- *  renders exactly two number inputs: Token Step then Layer Step. */
-async function pinSteps(page: Page, tokenStep: number, layerStep: number) {
-    const inputs = page.locator('#patch-lens-display input[type="number"]');
-    await inputs.nth(0).fill(String(tokenStep));
-    await inputs.nth(1).fill(String(layerStep));
+/** Pin the layer-step density so the grid (and Argos screenshots) don't depend
+ *  on the autofit's viewport-derived downsampling. Token rows are always shown
+ *  (no token-step control), so the toolbar renders one number input: Layer Step. */
+async function pinLayerStep(page: Page, layerStep: number) {
+    const input = page.locator('#patch-lens-display input[type="number"]').first();
+    await input.fill(String(layerStep));
 }
 
 test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
@@ -123,9 +122,9 @@ test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
     });
 
     test("tokens render their spaces as ␣ (row labels and cells)", async ({ page }) => {
-        // Show every row: autofit hides odd token indices at this viewport,
-        // and " Eiffel" is row index 1.
-        await pinSteps(page, 1, 8);
+        // Every token row is always shown now; pin the layer density for a
+        // stable layout. " Eiffel" is row index 1.
+        await pinLayerStep(page, 8);
 
         // Row label for the " Eiffel" token: raw token stays in title, display
         // shows the open-box marker.
@@ -142,35 +141,30 @@ test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
         await expect(eiffelCell).toHaveText("␣Eiffel");
     });
 
-    test("axis titles show the token/layer step", async ({ page }) => {
+    test("axis titles show the layer step; token axis has no step", async ({ page }) => {
         const display = page.locator("#patch-lens-display");
         // "Layer (Step: X)" renders above AND below the grid.
         await expect(display.getByText(/^Layer \(Step: \d+\)$/)).toHaveCount(2);
-        // Rotated y-axis title outside the scroll container.
-        await expect(display.getByText(/^Tokens \(Step: \d+\)$/)).toHaveCount(1);
+        // Token rows are never downsampled now, so the y-axis title is just
+        // "Tokens" (no step) and no "Tokens (Step: N)" appears.
+        await expect(display.getByText("Tokens", { exact: true })).toHaveCount(1);
+        await expect(display.getByText(/^Tokens \(Step:/)).toHaveCount(0);
     });
 
-    test("collapsed rows/columns show amber labeled expanders that expand on click", async ({
+    test("collapsed columns show an amber labeled expander that expands on click", async ({
         page,
     }) => {
-        // The 12-token × 32-layer fixture at 1280×720 always downsamples, so
-        // both gap expanders exist. The row expander carries a legible count
-        // label ("⋯ N hidden"), not the old faint 9px text.
-        const rowExpander = page.getByTestId("token-gap-expander").first();
-        await expect(rowExpander).toBeVisible();
-        await expect(rowExpander).toHaveText(/⋯ \d+ hidden/);
+        // Token rows are always shown (no token-step downsampling), so there is
+        // no token-gap-expander. Layers still downsample on the 32-layer fixture.
+        await expect(page.getByTestId("token-gap-expander")).toHaveCount(0);
 
         const colExpander = page.getByTestId("layer-gap-expander").first();
         await expect(colExpander).toBeVisible();
 
-        // Clicking an expander reveals the hidden rows/columns.
-        const rowsBefore = await tokenLabels(page).count();
-        await rowExpander.click();
-        expect(await tokenLabels(page).count()).toBeGreaterThan(rowsBefore);
-
+        // Clicking a column expander reveals the hidden layers (its own expander
+        // disappears once those layers are shown).
         const colsBefore = await page.getByTestId("layer-gap-expander").count();
         await colExpander.click();
-        // Expanding a column gap removes that expander (its layers are shown).
         expect(await page.getByTestId("layer-gap-expander").count()).toBeLessThan(colsBefore);
     });
 
@@ -194,9 +188,10 @@ test.describe("patch-lens workshop features (seeded, no NDIF)", () => {
     });
 
     test("visual: lens heatmap view", async ({ page }) => {
-        // Pin the density so the screenshot doesn't ride on autofit.
-        await pinSteps(page, 2, 8);
-        await expect(page.getByTestId("token-gap-expander").first()).toBeVisible();
+        // Pin the layer density so the screenshot doesn't ride on autofit. All
+        // token rows are shown; layers still downsample (amber column expander).
+        await pinLayerStep(page, 8);
+        await expect(page.getByTestId("layer-gap-expander").first()).toBeVisible();
         await argosScreenshot(page, "patch-lens-lens-view", { fullPage: false });
     });
 
@@ -244,9 +239,9 @@ test.describe("patch-lens intervention (seeded restore, no NDIF)", () => {
     test("visual: intervention (patching) view", async ({ page }) => {
         const resultHeader = page.getByRole("heading", { name: "Result (Intervened)" });
         await expect(resultHeader).toBeVisible();
-        // Pin the density (re-laying out the grids), then bring the result
+        // Pin the layer density (re-laying out the grids), then bring the result
         // into frame ourselves — the auto-scroll behavior has its own test.
-        await pinSteps(page, 1, 8);
+        await pinLayerStep(page, 8);
         await resultHeader.scrollIntoViewIfNeeded();
         // Let the reveal/cascade animations settle so the screenshot is stable.
         await page.waitForTimeout(1500);


### PR DESCRIPTION
Follow-up to #125 (pilot feedback): the **Token Step** control read as a confusing extra concept.

## Changes
- **Token rows are never downsampled** — the auto-fit fixes token-step at 1, so every token position is always shown; rows scroll if they overflow.
- **Compact rows** — `BASE_CELL_HEIGHT` 48 → 30 in the `edulogitlens` widget so a full prompt fits without a wall of tall rows.
- **Removed the Token Step toolbar control** (and its info tooltip). Only **Layer Step** remains — wide models still downsample layers.
- Token y-axis title is now just **"Tokens"** (no "(Step: N)"); no hidden-token amber bands appear.

Widget pin bumped `38d582a` → `ee9e098` (`jon-bell/edulogitlens@cm-only`). Tutorial copy and e2e specs updated (pin layer step only; assert no `token-gap-expander`; token axis is just "Tokens").

## Verification
- `tsc`/`prettier` clean on touched files; all 12 seeded Patch Lens Playwright tests pass locally.
- Screenshot-confirmed: toolbar has no Token Step, all 12 seeded token rows render compactly, no horizontal amber bands.
- Argos visual baselines (`patch-lens-lens-view`, intervention) will shift (shorter rows, all tokens) — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Reading the lens” tutorial text to clarify token visibility, downsampling behavior, amber band meaning, and how to expand hidden layers.
* **User Experience**
  * Streamlined patch-lens downsampling controls to use a single “Layer Step” input for the lens display.
* **Tests**
  * Updated end-to-end and visual regression assertions to match the revised control behavior and heatmap layout.
* **Chores**
  * Updated a bundled lens-related dependency to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->