### PR TITLE
J-Lens

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -903,8 +903,9 @@ wheels = [
 [[package]]
 name = "nnsightful"
 version = "0.1.0"
-source = { git = "https://github.com/AdamBelfki3/nnsightful.git#4c7cc2fa52d680a0d7ddfd6e9dff28d65734b888" }
+source = { git = "https://github.com/AdamBelfki3/nnsightful.git#75e42670b64f2aa5fcb82421e910376368c934d3" }
 dependencies = [
+    { name = "hf-xet" },
     { name = "ipython" },
     { name = "nnsight" },
     { name = "nnterp" },

--- a/workbench/_api/_metadata_cache.json
+++ b/workbench/_api/_metadata_cache.json
@@ -594,15 +594,594 @@
       "n_layers": 64,
       "params": "33B",
       "gated": true
+    },
+    "bigscience/bigscience-small-testing": {
+      "name": "bigscience/bigscience-small-testing",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "16M",
+      "gated": false
+    },
+    "microsoft/Phi-tiny-MoE-instruct": {
+      "name": "microsoft/Phi-tiny-MoE-instruct",
+      "is_chat": true,
+      "n_layers": 32,
+      "params": "4B",
+      "gated": false
+    },
+    "sbintuitions/tiny-lm-chat": {
+      "name": "sbintuitions/tiny-lm-chat",
+      "is_chat": true,
+      "n_layers": 4,
+      "params": "unknown",
+      "gated": false
+    },
+    "EleutherAI/pythia-70m-deduped": {
+      "name": "EleutherAI/pythia-70m-deduped",
+      "is_chat": false,
+      "n_layers": 6,
+      "params": "96M",
+      "gated": false
+    },
+    "yujiepan/deepseek-llm-tiny-random": {
+      "name": "yujiepan/deepseek-llm-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "410K",
+      "gated": false
+    },
+    "yujiepan/gpt-oss-tiny-random-mxfp4": {
+      "name": "yujiepan/gpt-oss-tiny-random-mxfp4",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "7M",
+      "gated": false
+    },
+    "yujiepan/codestral-v0.1-tiny-random": {
+      "name": "yujiepan/codestral-v0.1-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "526K",
+      "gated": false
+    },
+    "deepseek-ai/DeepSeek-V3": {
+      "name": "deepseek-ai/DeepSeek-V3",
+      "is_chat": false,
+      "n_layers": 61,
+      "params": "685B",
+      "gated": true
+    },
+    "yujiepan/mpt-tiny-random": {
+      "name": "yujiepan/mpt-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "405K",
+      "gated": false
+    },
+    "yujiepan/llama-3-tiny-random": {
+      "name": "yujiepan/llama-3-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "tiiuae/falcon-7b-instruct": {
+      "name": "tiiuae/falcon-7b-instruct",
+      "is_chat": true,
+      "n_layers": 32,
+      "params": "7B",
+      "gated": false
+    },
+    "yujiepan/mistral-v0.3-tiny-random": {
+      "name": "yujiepan/mistral-v0.3-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "526K",
+      "gated": false
+    },
+    "yujiepan/llama-3.3-tiny-random": {
+      "name": "yujiepan/llama-3.3-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "4M",
+      "gated": false
+    },
+    "yujiepan/opt-tiny-2layers-random": {
+      "name": "yujiepan/opt-tiny-2layers-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "420K",
+      "gated": false
+    },
+    "yujiepan/mixtral-8xtiny-random": {
+      "name": "yujiepan/mixtral-8xtiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "525K",
+      "gated": false
+    },
+    "yujiepan/gemma-tiny-random": {
+      "name": "yujiepan/gemma-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "deepseek-ai/DeepSeek-V2-Chat": {
+      "name": "deepseek-ai/DeepSeek-V2-Chat",
+      "is_chat": true,
+      "n_layers": 60,
+      "params": "236B",
+      "gated": true
+    },
+    "yujiepan/stablelm-2-tiny-random": {
+      "name": "yujiepan/stablelm-2-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "803K",
+      "gated": false
+    },
+    "yujiepan/deepseek-v2-tiny-random": {
+      "name": "yujiepan/deepseek-v2-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/glm-4.5-tiny-random": {
+      "name": "yujiepan/glm-4.5-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "3M",
+      "gated": false
+    },
+    "yujiepan/phi-3.5-tiny-random": {
+      "name": "yujiepan/phi-3.5-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "yujiepan/dbrx-tiny-random": {
+      "name": "yujiepan/dbrx-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "806K",
+      "gated": false
+    },
+    "yujiepan/phi-3-tiny-random": {
+      "name": "yujiepan/phi-3-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "yujiepan/QwQ-preview-tiny-random": {
+      "name": "yujiepan/QwQ-preview-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/mistral-tiny-random": {
+      "name": "yujiepan/mistral-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "514K",
+      "gated": false
+    },
+    "tiiuae/falcon-40b": {
+      "name": "tiiuae/falcon-40b",
+      "is_chat": false,
+      "n_layers": 60,
+      "params": "42B",
+      "gated": true
+    },
+    "yujiepan/gpt-oss-tiny-random-bf16": {
+      "name": "yujiepan/gpt-oss-tiny-random-bf16",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "7M",
+      "gated": false
+    },
+    "google/gemma-2-9b": {
+      "name": "google/gemma-2-9b",
+      "is_chat": false,
+      "n_layers": 42,
+      "params": "9B",
+      "gated": true
+    },
+    "yujiepan/dbrx-tiny256-random": {
+      "name": "yujiepan/dbrx-tiny256-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "64M",
+      "gated": false
+    },
+    "yujiepan/qwen2.5-tiny-random": {
+      "name": "yujiepan/qwen2.5-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "microsoft/Phi-3-mini-128k-instruct": {
+      "name": "microsoft/Phi-3-mini-128k-instruct",
+      "is_chat": true,
+      "n_layers": 32,
+      "params": "4B",
+      "gated": false
+    },
+    "yujiepan/glm-4-moe-tiny-random": {
+      "name": "yujiepan/glm-4-moe-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "3M",
+      "gated": false
+    },
+    "yujiepan/gptj-tiny-random": {
+      "name": "yujiepan/gptj-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/deepseek-v3-tiny-random": {
+      "name": "yujiepan/deepseek-v3-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "4M",
+      "gated": false
+    },
+    "yujiepan/ernie-4.5-tiny-random": {
+      "name": "yujiepan/ernie-4.5-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "854K",
+      "gated": false
+    },
+    "yujiepan/gemma-2-tiny-random": {
+      "name": "yujiepan/gemma-2-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/deepseek-v2-0628-tiny-random": {
+      "name": "yujiepan/deepseek-v2-0628-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/llama-2-tiny-3layers-random": {
+      "name": "yujiepan/llama-2-tiny-3layers-random",
+      "is_chat": false,
+      "n_layers": 3,
+      "params": "515K",
+      "gated": false
+    },
+    "qwen/Qwen2.5-0.5B": {
+      "name": "qwen/Qwen2.5-0.5B",
+      "is_chat": false,
+      "n_layers": 24,
+      "params": "494M",
+      "gated": false
+    },
+    "yujiepan/qwen1.5-moe-tiny-random": {
+      "name": "yujiepan/qwen1.5-moe-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "yujiepan/falcon-new-tiny64-random": {
+      "name": "yujiepan/falcon-new-tiny64-random",
+      "is_chat": false,
+      "n_layers": 1,
+      "params": "4M",
+      "gated": false
+    },
+    "yujiepan/phi-3.5-moe-tiny-random": {
+      "name": "yujiepan/phi-3.5-moe-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "yujiepan/glm-4-tiny-random": {
+      "name": "yujiepan/glm-4-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "5M",
+      "gated": false
+    },
+    "yujiepan/deepseek-v3.1-tiny-random": {
+      "name": "yujiepan/deepseek-v3.1-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "5M",
+      "gated": false
+    },
+    "deepseek-ai/DeepSeek-V2-Chat-0628": {
+      "name": "deepseek-ai/DeepSeek-V2-Chat-0628",
+      "is_chat": true,
+      "n_layers": 60,
+      "params": "236B",
+      "gated": true
+    },
+    "yujiepan/falcon-tiny-random": {
+      "name": "yujiepan/falcon-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "522K",
+      "gated": false
+    },
+    "yujiepan/llama-3.1-tiny-random": {
+      "name": "yujiepan/llama-3.1-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/opt-tiny-random": {
+      "name": "yujiepan/opt-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "420K",
+      "gated": false
+    },
+    "yujiepan/llama-3.3-tiny-random-dim64": {
+      "name": "yujiepan/llama-3.3-tiny-random-dim64",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "8M",
+      "gated": false
+    },
+    "yujiepan/qwen2-tiny-random": {
+      "name": "yujiepan/qwen2-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/qwen3-tiny-random-tp": {
+      "name": "yujiepan/qwen3-tiny-random-tp",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "microsoft/Phi-3.5-MoE-instruct": {
+      "name": "microsoft/Phi-3.5-MoE-instruct",
+      "is_chat": true,
+      "n_layers": 32,
+      "params": "42B",
+      "gated": true
+    },
+    "yujiepan/llama-2-tiny-random": {
+      "name": "yujiepan/llama-2-tiny-random",
+      "is_chat": false,
+      "n_layers": 1,
+      "params": "513K",
+      "gated": false
+    },
+    "yujiepan/qwen1.5-tiny-random": {
+      "name": "yujiepan/qwen1.5-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "yujiepan/kimi-k2-tiny-random": {
+      "name": "yujiepan/kimi-k2-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "11M",
+      "gated": false
+    },
+    "axolotl-ai-co/gemma-3-34M": {
+      "name": "axolotl-ai-co/gemma-3-34M",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "34M",
+      "gated": false
+    },
+    "yujiepan/mixtral-8xtiny-random-openvino-8bit": {
+      "name": "yujiepan/mixtral-8xtiny-random-openvino-8bit",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "unknown",
+      "gated": false
+    },
+    "yujiepan/falcon-new-tiny-random": {
+      "name": "yujiepan/falcon-new-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "523K",
+      "gated": false
+    },
+    "yujiepan/baguettotron-tiny-random": {
+      "name": "yujiepan/baguettotron-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "552K",
+      "gated": false
+    },
+    "yujiepan/smollm-tiny-random": {
+      "name": "yujiepan/smollm-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "394K",
+      "gated": false
+    },
+    "gpt2": {
+      "name": "gpt2",
+      "is_chat": false,
+      "n_layers": 12,
+      "params": "137M",
+      "gated": false
+    },
+    "yujiepan/starcoder-tiny-random": {
+      "name": "yujiepan/starcoder-tiny-random",
+      "is_chat": false,
+      "n_layers": 1,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/bloom-tiny-random": {
+      "name": "yujiepan/bloom-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/ernie-4.5-moe-tiny-random": {
+      "name": "yujiepan/ernie-4.5-moe-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "904K",
+      "gated": false
+    },
+    "yujiepan/mistral-nemo-2407-tiny-random": {
+      "name": "yujiepan/mistral-nemo-2407-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/qwen2.5-128k-tiny-random": {
+      "name": "yujiepan/qwen2.5-128k-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/llama-3.2-tiny-random": {
+      "name": "yujiepan/llama-3.2-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "yujiepan/phi-moe-tiny-random": {
+      "name": "yujiepan/phi-moe-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "3M",
+      "gated": false
+    },
+    "yujiepan/gpt-oss-tiny-random": {
+      "name": "yujiepan/gpt-oss-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "7M",
+      "gated": false
+    },
+    "yujiepan/smollm3-tiny-random": {
+      "name": "yujiepan/smollm3-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "8M",
+      "gated": false
+    },
+    "yujiepan/qwen3-moe-tiny-random": {
+      "name": "yujiepan/qwen3-moe-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "10M",
+      "gated": false
+    },
+    "yujiepan/phi-4-tiny-random": {
+      "name": "yujiepan/phi-4-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "3M",
+      "gated": false
+    },
+    "yujiepan/QwQ-tiny-random": {
+      "name": "yujiepan/QwQ-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "2M",
+      "gated": false
+    },
+    "yujiepan/mixtral-tiny-random": {
+      "name": "yujiepan/mixtral-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "258K",
+      "gated": false
+    },
+    "yujiepan/mathstral-v0.1-tiny-random": {
+      "name": "yujiepan/mathstral-v0.1-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "526K",
+      "gated": false
+    },
+    "yujiepan/qwen3-tiny-random": {
+      "name": "yujiepan/qwen3-tiny-random",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "10M",
+      "gated": false
+    },
+    "yujiepan/falcon-new-tiny-random-awq-w4g64": {
+      "name": "yujiepan/falcon-new-tiny-random-awq-w4g64",
+      "is_chat": false,
+      "n_layers": 1,
+      "params": "8M",
+      "gated": false
+    },
+    "yujiepan/qwq-tiny-random-dim64": {
+      "name": "yujiepan/qwq-tiny-random-dim64",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "20M",
+      "gated": false
+    },
+    "yujiepan/llama-3-tiny-random-gptq-w4": {
+      "name": "yujiepan/llama-3-tiny-random-gptq-w4",
+      "is_chat": false,
+      "n_layers": 2,
+      "params": "1M",
+      "gated": false
+    },
+    "EleutherAI/pythia-6.9b": {
+      "name": "EleutherAI/pythia-6.9b",
+      "is_chat": false,
+      "n_layers": 32,
+      "params": "7B",
+      "gated": false
+    },
+    "allenai/OLMo-2-0425-1B": {
+      "name": "allenai/OLMo-2-0425-1B",
+      "is_chat": false,
+      "n_layers": 16,
+      "params": "1B",
+      "gated": false
     }
   },
   "unsupported": [
+    "DeepFloyd/IF-I-L-v1.0",
+    "MiniMaxAI/MiniMax-M2",
+    "MiniMaxAI/MiniMax-M2.5",
+    "NeelNanda/pile-10k",
+    "Qwen/Qwen3-VL-2B-Instruct",
+    "Qwen/Qwen3-VL-8B-Instruct",
     "Qwen/Qwen3.5-27B",
     "Qwen/Qwen3.5-9B",
     "Qwen/Qwen3.6-35B-A3B",
+    "SakanaAI/Llama-2-7b-hf-DroPE",
+    "THUDM/LongBench",
     "allenai/OLMo-7B",
+    "andyrdt/04_2026_puzzle_1a",
+    "andyrdt/04_2026_puzzle_1b",
+    "black-forest-labs/FLUX.1-schnell",
     "deepseek-ai/deepseek-moe-16b-base",
     "facebook/esmfold_v1",
+    "glue",
     "google/gemma-3-12b-it",
     "google/gemma-3-12b-pt",
     "google/gemma-3-27b-it",
@@ -612,14 +1191,111 @@
     "google/gemma-4-12B-it",
     "google/gemma-4-26B-A4B",
     "google/gemma-4-31B",
+    "hf-internal-testing/tiny-stable-diffusion-pipe",
+    "ivanzhouyq/RedPajama-Tiny",
     "kernels-community/triton_kernels",
     "lewtun/talkie-1930-13b-it-hf",
     "llava-hf/llava-1.5-7b-hf",
+    "llava-hf/llava-interleave-qwen-0.5b-hf",
     "meta-llama/Llama-3-8B-instruct",
+    "mib-bench/arc_challenge",
+    "mib-bench/arc_easy",
+    "mib-bench/arithmetic_addition",
+    "mib-bench/arithmetic_subtraction",
+    "mib-bench/copycolors_mcqa",
+    "mib-bench/ioi",
+    "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
     "mlabonne/gemma-3-27b-it-abliterated",
     "moonshotai/Kimi-K2.5",
     "mosaicml/mpt-30b",
+    "neuronpedia/jacobian-lens",
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+    "nvidia/Qwen3.6-35B-A3B-NVFP4",
+    "segmind/tiny-sd",
     "stabilityai/stable-diffusion-xl-base-1.0",
-    "stable-diffusion-v1-5/stable-diffusion-v1-5"
+    "stable-diffusion-v1-5/stable-diffusion-v1-5",
+    "wikitext",
+    "yujiepan/apertus-tiny-random",
+    "yujiepan/apriel-1.5-tiny-random",
+    "yujiepan/bailing-moe-v2-tiny-random",
+    "yujiepan/bailing-moe-v2.5-tiny-random",
+    "yujiepan/chatglm3-tiny-random",
+    "yujiepan/clip-vit-tiny-random-patch14-336",
+    "yujiepan/devstral-2-tiny-random",
+    "yujiepan/ernie-4.5-vl-moe-tiny-random",
+    "yujiepan/gemma-3-tiny-random",
+    "yujiepan/gemma-4-dense-tiny-random",
+    "yujiepan/gemma-4-e-tiny-random",
+    "yujiepan/gemma-4-moe-tiny-random",
+    "yujiepan/gemma-4e-tiny-random",
+    "yujiepan/glm-4-moe-lite-tiny-random",
+    "yujiepan/glm-4.1v-tiny-random",
+    "yujiepan/glm-4.5v-tiny-random",
+    "yujiepan/glm-4.6v-tiny-random",
+    "yujiepan/glm-4.7-flash-tiny-random",
+    "yujiepan/glm-4v-moe-tiny-random",
+    "yujiepan/glm-4v-tiny-random",
+    "yujiepan/glm-5-tiny-random",
+    "yujiepan/glm-5.1-tiny-random",
+    "yujiepan/glm-moe-dsa-tiny-random",
+    "yujiepan/glm-ocr-tiny-random",
+    "yujiepan/grok-1-tiny-random",
+    "yujiepan/hunyuan-dense-v1-tiny-random",
+    "yujiepan/hunyuan-moe-tiny-random",
+    "yujiepan/hunyuan-tiny-random",
+    "yujiepan/hy-v3-tiny-random",
+    "yujiepan/hy3-tiny-random",
+    "yujiepan/hymba-tiny-random",
+    "yujiepan/internlm2-tiny-random",
+    "yujiepan/kimi-k2.5-tiny-random",
+    "yujiepan/kimi-k2.6-tiny-random",
+    "yujiepan/kimi-linear-tiny-random",
+    "yujiepan/kormo-tiny-random",
+    "yujiepan/llama-4-8E-tiny-random",
+    "yujiepan/llama-4-tiny-random",
+    "yujiepan/llava-onevision-1.5-tiny-random",
+    "yujiepan/longcat-flash-lite-tiny-random",
+    "yujiepan/longcat-flash-ngram-tiny-random",
+    "yujiepan/longcat-flash-tiny-random",
+    "yujiepan/minicpm-v-4-tiny-random",
+    "yujiepan/minicpm-v-4_5-tiny-random",
+    "yujiepan/minicpm4-tiny-random",
+    "yujiepan/minicpm4.1-tiny-random",
+    "yujiepan/minimax-m1-tiny-random",
+    "yujiepan/minimax-m2-tiny-random",
+    "yujiepan/minimax-m2.5-tiny-random",
+    "yujiepan/minimax-m2.7-tiny-random",
+    "yujiepan/ministral-3-tiny-random",
+    "yujiepan/mistral-3-tiny-random",
+    "yujiepan/mistral-small-4-tiny-random",
+    "yujiepan/olmo-3-tiny-random",
+    "yujiepan/omnivoice-tiny-random",
+    "yujiepan/openai-privacy-filter-tiny-random",
+    "yujiepan/phi-3-vision-tiny-random",
+    "yujiepan/phi-4-flash-tiny-random",
+    "yujiepan/phi-4-multimodal-tiny-random",
+    "yujiepan/qvq-preview-tiny-random",
+    "yujiepan/qwen-vl-tiny-random",
+    "yujiepan/qwen2-audio-tiny-random",
+    "yujiepan/qwen2-vl-tiny-random",
+    "yujiepan/qwen2.5-omni-tiny-random",
+    "yujiepan/qwen3-next-moe-tiny-random",
+    "yujiepan/qwen3-vl-moe-tiny-random",
+    "yujiepan/qwen3-vl-tiny-random",
+    "yujiepan/qwen3.5-moe-tiny-random",
+    "yujiepan/qwen3.5-tiny-random",
+    "yujiepan/qwen3.6-moe-tiny-random",
+    "yujiepan/qwen3.6-tiny-random",
+    "yujiepan/ring-2.5-tiny-random",
+    "yujiepan/ring-tiny-random",
+    "yujiepan/sam3-tiny-random",
+    "yujiepan/seed-oss-tiny-random",
+    "yujiepan/step3-tiny-random",
+    "yujiepan/step3-tiny-random-vllm",
+    "yujiepan/step3-vl-tiny-random",
+    "yujiepan/tiny-random-SwinModel",
+    "yujiepan/tiny-random-swin-patch4-window7-224",
+    "yujiepan/voxtral-tiny-random",
+    "yujiepan/zaya1-tiny-random"
   ]
 }

--- a/workbench/_api/main.py
+++ b/workbench/_api/main.py
@@ -4,7 +4,7 @@ import logging
 import os
 import anyio
 
-from .routes import lens, patch, models, logit_lens, activation_patching, causal_mediation
+from .routes import lens, patch, models, logit_lens, j_lens, activation_patching, causal_mediation
 from .state import AppState
 
 from dotenv import load_dotenv; load_dotenv()
@@ -57,6 +57,7 @@ def fastapi_app():
 
     app.include_router(lens, prefix="/lens")
     app.include_router(logit_lens, prefix="/logit_lens")
+    app.include_router(j_lens, prefix="/j_lens")
     app.include_router(activation_patching, prefix="/activation_patching")
     app.include_router(causal_mediation, prefix="/causal_mediation", tags=["causal_mediation"])
     app.include_router(patch, prefix="/patch")

--- a/workbench/_api/routes/__init__.py
+++ b/workbench/_api/routes/__init__.py
@@ -2,6 +2,7 @@ from .lens import router as lens
 from .patch import router as patch
 from .models import router as models
 from .logit_lens import router as logit_lens
+from .j_lens import router as j_lens
 from .activation_patching import router as activation_patching
 from .causal_mediation import router as causal_mediation
 
@@ -14,6 +15,7 @@ __all__ = [
     "patch",
     "models",
     "logit_lens",
+    "j_lens",
     "activation_patching",
     "causal_mediation",
 ]

--- a/workbench/_api/routes/j_lens.py
+++ b/workbench/_api/routes/j_lens.py
@@ -30,7 +30,7 @@ async def start_j_lens(
     model = state[req.model]
     backend = state.make_backend(model=model)
 
-    output = j_lens._run(model, req.prompt, remote=state.remote, backend=backend, non_blocking=state.remote, raw=False)
+    output = j_lens._run(model, req.prompt, remote=state.remote, backend=backend, non_blocking=state.remote, raw=False, top_k=req.topk)
 
     if not backend.blocking:
         return {"job_id": output}

--- a/workbench/_api/routes/j_lens.py
+++ b/workbench/_api/routes/j_lens.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from ..state import AppState, get_state
+from ..auth import require_user_email
+
+from ..data_models import NDIFResponse
+
+from nnsightful.types import JLensData
+from nnsightful.tools.j_lens import j_lens
+
+router = APIRouter()
+
+class JLensRequest(BaseModel):
+    model: str
+    prompt: str
+    topk: int = 5  # Number of top-k predictions per cell
+    include_entropy: bool = True  # Whether to include entropy data
+
+
+class JLensResponse(NDIFResponse):
+    data: JLensData | None = None
+
+
+@router.post("/start", response_model=JLensResponse)
+async def start_j_lens(
+    req: JLensRequest,
+    state: AppState = Depends(get_state),
+    user_email: str = Depends(require_user_email),
+):
+    model = state[req.model]
+    backend = state.make_backend(model=model)
+
+    output = j_lens._run(model, req.prompt, remote=state.remote, backend=backend, non_blocking=state.remote, raw=False)
+
+    if not backend.blocking:
+        return {"job_id": output}
+
+
+    return {"data": j_lens.to_data_obj(**output)}
+
+
+@router.post("/results/{job_id}", response_model=JLensResponse)
+async def collect_j_lens(
+    job_id: str,
+    req: JLensRequest,
+    state: AppState = Depends(get_state),
+    user_email: str = Depends(require_user_email),
+):
+    backend = state.make_backend(job_id=job_id)
+    results = backend()['results']
+
+    data = j_lens.to_data_obj(**results)
+
+    return {"data": data}

--- a/workbench/_api/routes/logit_lens.py
+++ b/workbench/_api/routes/logit_lens.py
@@ -30,7 +30,7 @@ async def start_logit_lens(
     model = state[req.model]
     backend = state.make_backend(model=model)
 
-    output = logit_lens._run(model, req.prompt, remote=state.remote, backend=backend, non_blocking=state.remote, raw=False)
+    output = logit_lens._run(model, req.prompt, remote=state.remote, backend=backend, non_blocking=state.remote, raw=False, top_k=req.topk)
 
     if not backend.blocking:
         return {"job_id": output}

--- a/workbench/_api/routes/models.py
+++ b/workbench/_api/routes/models.py
@@ -6,6 +6,8 @@ import torch as t
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from nnsightful.tools.j_lens import j_lens
+
 from ..auth import get_user_email, require_user_email, user_has_model_access
 from ..data_models import NDIFResponse, Token, ModelHeat
 from ..telemetry import TelemetryClient, RequestStatus
@@ -103,15 +105,22 @@ async def get_models(
     if state.remote:
         is_user_signed_in: bool = user_email is not None and user_email != "guest@localhost"
         models = get_remote_models(state, is_user_signed_in)
-
-        return models
-
     else:
         models = state.get_all_model_list()
         # Local models are fully loaded on the dev backend, so they're effectively hot.
         for model in models:
             model['status'] = ModelHeat.HOT.value
-        return models
+        
+    ## JLens supported models
+    try:
+        lens_models = j_lens.get_available_lenses()
+        for model in models:
+            name = model.get("name", "")
+            model["has_jacobian"] = name.rsplit("/", 1)[-1] in lens_models
+    except Exception as e:
+        logger.warning(f"Failed to fetch Jacobian lens availability: {e}")
+
+    return models
 
 
 class LensCompletion(BaseModel):

--- a/workbench/_web/bun.lock
+++ b/workbench/_web/bun.lock
@@ -1100,7 +1100,7 @@
 
     "easy-table": ["easy-table@1.1.0", "", { "optionalDependencies": { "wcwidth": ">=1.0.1" } }, "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA=="],
 
-    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#b61fe39", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-b61fe39", "sha512-cU+PafkevpPVgNDc/iCLDrkAJenhrGAUxL5/2UTG3/kpeVaGR3fI7ZPK6v7ihQs8k+hcJwJjIvk/KGMS2Vlq0g=="],
+    "edulogitlens": ["edulogitlens@github:jon-bell/edulogitlens#b61fe39", { "dependencies": { "lucide-react": "^0.487.0", "motion": "^12.23.24", "react-dnd": "^16.0.1", "react-dnd-html5-backend": "^16.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "jon-bell-edulogitlens-b61fe39"],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.200", "", {}, "sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w=="],
 
@@ -1498,7 +1498,7 @@
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
-    "nnsightful": ["nnsightful@github:AdamBelfki3/nnsightful#4c7cc2f", { "peerDependencies": { "react": "^18.2.0 || ^19.0.0", "react-dom": "^18.2.0 || ^19.0.0" } }, "AdamBelfki3-nnsightful-4c7cc2f"],
+    "nnsightful": ["nnsightful@github:AdamBelfki3/nnsightful#75e4267", { "peerDependencies": { "react": "^18.2.0 || ^19.0.0", "react-dom": "^18.2.0 || ^19.0.0" } }, "AdamBelfki3-nnsightful-75e4267"],
 
     "node-abi": ["node-abi@3.75.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg=="],
 

--- a/workbench/_web/src/app/workbench/[workspaceId]/activation-patching/[chartId]/components/ActivationPatchingControls.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/activation-patching/[chartId]/components/ActivationPatchingControls.tsx
@@ -1025,6 +1025,10 @@ export function ActivationPatchingControls({
         <>
             <ToolPanelHeader
                 title="Activation Patching"
+                reference={{
+                    href: "https://rome.baulab.info/",
+                    label: "Activation Patching reference (rome.baulab.info)",
+                }}
                 viewMode={viewMode}
                 showReset={showReset}
                 showSync={showSync}

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCard.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCard.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { Grid3X3, ChartLine, Trash2, Copy, MoreVertical, GitBranch } from "lucide-react";
 import { ChartMetadata, ChartType } from "@/types/charts";
 import { PatchLensIcon } from "@/components/PatchLensIcon";
+import { JLensIcon } from "@/components/JLensIcon";
 import { cn } from "@/lib/utils";
 import { ChartRenameDialog } from "./ChartRenameDialog";
 import { sidebarCardShell } from "./sidebarCardShell";
@@ -26,7 +27,7 @@ const TOOL_META: Record<
     line: { label: "Line", Icon: ChartLine },
     heatmap: { label: "Heatmap", Icon: Grid3X3 },
     lens2: { label: "Logit Lens", Icon: Grid3X3 },
-    jlens: { label: "J-Lens", Icon: Grid3X3 },
+    jlens: { label: "J-Lens", Icon: JLensIcon },
     "activation-patching": { label: "Act. Patching", Icon: GitBranch },
     "patch-lens": { label: "Patch Lens", Icon: PatchLensIcon },
 };

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCard.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCard.tsx
@@ -26,6 +26,7 @@ const TOOL_META: Record<
     line: { label: "Line", Icon: ChartLine },
     heatmap: { label: "Heatmap", Icon: Grid3X3 },
     lens2: { label: "Logit Lens", Icon: Grid3X3 },
+    jlens: { label: "J-Lens", Icon: Grid3X3 },
     "activation-patching": { label: "Act. Patching", Icon: GitBranch },
     "patch-lens": { label: "Patch Lens", Icon: PatchLensIcon },
 };
@@ -48,6 +49,8 @@ export default function ChartCard({ metadata, handleDelete, canDelete }: ChartCa
     const navigateToChart = (chart: ChartMetadata) => {
         if (chart.toolType === "lens2" || chart.chartType === "lens2") {
             router.push(`/workbench/${workspaceId}/lens2/${chart.id}`);
+        } else if (chart.toolType === "jlens" || chart.chartType === "jlens") {
+            router.push(`/workbench/${workspaceId}/j-lens/${chart.id}`);
         } else if (
             chart.toolType === "activation-patching" ||
             chart.chartType === "activation-patching"

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCardsSidebar.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCardsSidebar.tsx
@@ -5,6 +5,7 @@ import { getChartsMetadata } from "@/lib/queries/chartQueries";
 import { useParams, useRouter } from "next/navigation";
 import {
     useCreateLens2ChartPair,
+    useCreateJLensChartPair,
     useCreatePatchLensChartPair,
     useCreatePatchChartPair,
     useCreateActivationPatchingChartPair,
@@ -37,6 +38,7 @@ import {
     PanelLeftOpen,
     FileText,
     Layers,
+    Layers3,
     GitBranch,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -79,6 +81,7 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
     const { data: workshop } = useWorkspaceWorkshop(workspaceId as string);
 
     const { mutate: createLens2Pair, isPending: isCreatingLens2 } = useCreateLens2ChartPair();
+    const { mutate: createJLensPair, isPending: isCreatingJLens } = useCreateJLensChartPair();
     const { mutate: createPatchLensPair, isPending: isCreatingPatchLens } =
         useCreatePatchLensChartPair();
     const { mutate: createPatchPair, isPending: isCreatingPatch } = useCreatePatchChartPair();
@@ -215,6 +218,8 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
         // Route based on tool type
         if (toolType === "lens2") {
             router.push(`/workbench/${workspaceId}/lens2/${chartId}`);
+        } else if (toolType === "jlens") {
+            router.push(`/workbench/${workspaceId}/j-lens/${chartId}`);
         } else if (toolType === "activation-patching") {
             router.push(`/workbench/${workspaceId}/activation-patching/${chartId}`);
         } else if (toolType === "patch-lens") {
@@ -228,7 +233,9 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
         router.push(`/workbench/${workspaceId}/overview/${documentId}`);
     };
 
-    const handleCreate = (toolType: "lens2" | "patch" | "activation-patching" | "patch-lens") => {
+    const handleCreate = (
+        toolType: "lens2" | "jlens" | "patch" | "activation-patching" | "patch-lens",
+    ) => {
         // Guard against stale UI / programmatic calls; the buttons below are
         // already filtered. createChartConfigPair re-checks server-side.
         if (workshop && !workshop.allowedTools.includes(toolType as WorkshopTool)) return;
@@ -238,6 +245,15 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
                 { workspaceId: workspaceId as string },
                 {
                     onSuccess: ({ chart }) => navigateToChart(chart.id, "lens2"),
+                },
+            );
+            return;
+        }
+        if (toolType === "jlens") {
+            createJLensPair(
+                { workspaceId: workspaceId as string },
+                {
+                    onSuccess: ({ chart }) => navigateToChart(chart.id, "jlens"),
                 },
             );
             return;
@@ -348,6 +364,7 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
 
     const isCreatingAny =
         isCreatingLens2 ||
+        isCreatingJLens ||
         isCreatingPatchLens ||
         isCreatingPatch ||
         isCreatingActivationPatching ||
@@ -364,6 +381,13 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
             isCreating: isCreatingLens2,
         },
         {
+            tool: "jlens" as const,
+            label: "J-Lens",
+            title: "New J-Lens visualization",
+            Icon: Layers3,
+            isCreating: isCreatingJLens,
+        },
+        {
             tool: "activation-patching" as const,
             label: "Activation Patching",
             title: "New Activation Patching",
@@ -377,7 +401,7 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
             Icon: PatchLensIcon,
             isCreating: isCreatingPatchLens,
         },
-    ].filter(({ tool }) => !workshop || workshop.allowedTools.includes(tool));
+    ].filter(({ tool }) => !workshop || workshop.allowedTools.includes(tool as WorkshopTool));
 
     const actionButtons = (
         <div className="flex flex-col w-full gap-2 text-sm">

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCardsSidebar.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/ChartCardsSidebar.tsx
@@ -38,12 +38,12 @@ import {
     PanelLeftOpen,
     FileText,
     Layers,
-    Layers3,
     GitBranch,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { PatchLensIcon } from "@/components/PatchLensIcon";
+import { JLensIcon } from "@/components/JLensIcon";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     DndContext,
@@ -384,7 +384,7 @@ export default function ChartCardsSidebar({ fillWidth = false }: { fillWidth?: b
             tool: "jlens" as const,
             label: "J-Lens",
             title: "New J-Lens visualization",
-            Icon: Layers3,
+            Icon: JLensIcon,
             isCreating: isCreatingJLens,
         },
         {

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/MobileCollapsibleControls.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/MobileCollapsibleControls.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { ChevronDown, ChevronUp, type LucideIcon } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import type { ComponentType } from "react";
 
 export function MobileCollapsibleControls({
     children,
@@ -11,7 +12,7 @@ export function MobileCollapsibleControls({
 }: {
     children: ReactNode;
     label: string;
-    icon: LucideIcon;
+    icon: ComponentType<{ className?: string }>;
     isRunning?: boolean;
 }) {
     const [collapsed, setCollapsed] = useState(false);

--- a/workbench/_web/src/app/workbench/[workspaceId]/components/ToolPanelHeader.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/components/ToolPanelHeader.tsx
@@ -1,10 +1,13 @@
-import { RotateCcw } from "lucide-react";
+import { BookOpen, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface ToolPanelHeaderProps {
     /** Panel title (e.g. "Logit Lens", "Activation Patching"). */
     title: string;
+    /** Optional reference link (e.g. the tool's paper) shown as a small book
+     * icon next to the title. */
+    reference?: { href: string; label: string };
     /** True when models are unavailable AND not currently fetching — shows
      * the compact ⚠ View Mode indicator. */
     viewMode: boolean;
@@ -32,6 +35,7 @@ interface ToolPanelHeaderProps {
  */
 export function ToolPanelHeader({
     title,
+    reference,
     viewMode,
     showReset,
     showSync,
@@ -42,7 +46,21 @@ export function ToolPanelHeader({
 }: ToolPanelHeaderProps) {
     return (
         <div className="p-3 border-b flex items-center justify-between">
-            <h2 className="text-sm pl-2 font-medium">{title}</h2>
+            <div className="flex items-center gap-1.5 pl-2">
+                <h2 className="text-sm font-medium">{title}</h2>
+                {reference && (
+                    <a
+                        href={reference.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={reference.label}
+                        title={reference.label}
+                        className="text-muted-foreground/50 transition-colors hover:text-foreground"
+                    >
+                        <BookOpen className="h-3.5 w-3.5" />
+                    </a>
+                )}
+            </div>
             <div className="flex items-center gap-1.5">
                 {viewMode && (
                     <span

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensArea.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensArea.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useToolArea } from "@/hooks/useToolArea";
+import { JLensControls } from "./JLensControls";
+import { JLensConfigData, JLensData } from "@/types/jlens";
+
+interface JLensConfig {
+    id: string;
+    data: JLensConfigData;
+    type: string;
+}
+
+interface JLensChart {
+    id: string;
+    data: JLensData | null;
+    type: string;
+}
+
+export default function JLensArea() {
+    const {
+        config,
+        isChartLoading,
+        modelsAvailable,
+        modelsFetching,
+        effectiveModel,
+        hasExistingData,
+        modelRunnable,
+    } = useToolArea<JLensConfig, JLensChart>();
+
+    if (!config || isChartLoading) {
+        return (
+            <div className="h-full flex flex-col md:min-w-64">
+                <div className="p-3 border-b flex items-center justify-between">
+                    <h2 className="text-sm pl-2 font-medium">J-Lens</h2>
+                </div>
+                <div className="h-48 animate-pulse bg-muted/50 m-3 rounded" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="h-full flex flex-col md:min-w-64">
+            <JLensControls
+                key={config.id}
+                initialConfig={config}
+                selectedModel={effectiveModel}
+                // Treat a non-runnable (cold/gone) saved model as read-only,
+                // reusing the existing models-unavailable path. The saved
+                // result still renders read-only in the Display.
+                modelsAvailable={modelsAvailable && modelRunnable}
+                modelsLoading={modelsFetching}
+                hasExistingData={hasExistingData}
+            />
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensArea.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensArea.tsx
@@ -25,6 +25,7 @@ export default function JLensArea() {
         effectiveModel,
         hasExistingData,
         modelRunnable,
+        isModelSupported,
     } = useToolArea<JLensConfig, JLensChart>();
 
     if (!config || isChartLoading) {
@@ -50,6 +51,10 @@ export default function JLensArea() {
                 modelsAvailable={modelsAvailable && modelRunnable}
                 modelsLoading={modelsFetching}
                 hasExistingData={hasExistingData}
+                // j-lens only supports models that have a Jacobian lens; when
+                // the active model doesn't, the controls grey out and invite a
+                // model change (the picker also disables such models).
+                modelSupported={isModelSupported}
             />
         </div>
     );

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensControls.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensControls.tsx
@@ -520,6 +520,10 @@ export function JLensControls({
         <>
             <ToolPanelHeader
                 title="J-Lens"
+                reference={{
+                    href: "https://transformer-circuits.pub/2026/workspace/index.html",
+                    label: "J-Lens reference (transformer-circuits.pub)",
+                }}
                 viewMode={viewMode}
                 showReset={showReset}
                 showSync={showSync}

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensControls.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensControls.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Loader2, Play } from "lucide-react";
+import { Loader2, Play, TriangleAlert } from "lucide-react";
 import { useJLens } from "@/lib/api/jlensApi";
 import { useUpdateChartConfig } from "@/lib/api/configApi";
 import { JLensConfigData } from "@/types/jlens";
@@ -37,6 +37,10 @@ interface JLensControlsProps {
      * an error. */
     modelsLoading?: boolean;
     hasExistingData?: boolean;
+    /** Whether the selected model supports j-lens (has a Jacobian lens). When
+     * false the controls are greyed out and a banner invites picking another
+     * model. Defaults to true. */
+    modelSupported?: boolean;
 }
 
 const TOKEN_STYLES = {
@@ -87,6 +91,7 @@ export function JLensControls({
     modelsAvailable,
     modelsLoading = false,
     hasExistingData = false,
+    modelSupported = true,
 }: JLensControlsProps) {
     const { workspaceId, chartId } = useParams<{ workspaceId: string; chartId: string }>();
 
@@ -132,7 +137,9 @@ export function JLensControls({
     const { mutateAsync: updateConfig, isPending: isUpdatingConfig } = useUpdateChartConfig();
 
     const isExecuting = isComputing || isUpdatingConfig;
-    const interactive = modelsAvailable && !isExecuting;
+    // An unsupported model (no Jacobian lens) makes the controls read-only, the
+    // same way an unavailable/cold model does — the run can't succeed.
+    const interactive = modelsAvailable && !isExecuting && modelSupported;
 
     useEffect(() => {
         const configPrompt = initialConfig.data?.prompt || "";
@@ -521,6 +528,25 @@ export function JLensControls({
                 onSync={updateConfigModel}
             />
             <div className="p-3 flex-1 overflow-auto flex flex-col gap-4">
+                {!modelSupported && (
+                    <div
+                        role="status"
+                        className="flex items-start gap-2 rounded border border-amber-300/70 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700/40 dark:bg-amber-950/30 dark:text-amber-200"
+                    >
+                        <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                        <span>
+                            {selectedModel ? (
+                                <>
+                                    <span className="font-medium">{selectedModel}</span> has no
+                                    J-Lens (Jacobian lens).
+                                </>
+                            ) : (
+                                "This model has no J-Lens (Jacobian lens)."
+                            )}{" "}
+                            Pick a model with a lens from the header to run J-Lens.
+                        </span>
+                    </div>
+                )}
                 <div className="flex flex-col gap-2">
                     <Label className="text-sm font-medium">Prompt</Label>
                     <div className="relative">

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensControls.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensControls.tsx
@@ -1,0 +1,614 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Loader2, Play } from "lucide-react";
+import { useJLens } from "@/lib/api/jlensApi";
+import { useUpdateChartConfig } from "@/lib/api/configApi";
+import { JLensConfigData } from "@/types/jlens";
+import { Slider } from "@/components/ui/slider";
+import { Checkbox } from "@/components/ui/checkbox";
+import { encodeText } from "@/actions/tok";
+import { TokenizerLoadError } from "@/actions/errors";
+import { Token } from "@/types/models";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import { jlensConfigEqualsExceptModel, tokenTextSequencesEqual } from "@/lib/configModelDiff";
+import { useDraftModel } from "@/hooks/useDraftModel";
+import { useBlurTokenizeScheduler } from "@/hooks/useBlurTokenizeScheduler";
+import { useBackgroundTokenPair } from "@/hooks/useBackgroundTokenPair";
+import { ToolPanelHeader } from "@/app/workbench/[workspaceId]/components/ToolPanelHeader";
+
+interface JLensConfig {
+    id: string;
+    data: JLensConfigData;
+    type: string;
+}
+
+interface JLensControlsProps {
+    initialConfig: JLensConfig;
+    selectedModel: string;
+    modelsAvailable: boolean;
+    /** True while the models query is in flight. Used to suppress the
+     * "unavailable" banner during a fetch — even if the previous state was
+     * an error. */
+    modelsLoading?: boolean;
+    hasExistingData?: boolean;
+}
+
+const TOKEN_STYLES = {
+    base: "!text-sm !leading-5 whitespace-pre-wrap break-words select-none !box-border relative",
+    hover: "hover:bg-primary/20 hover:ring-1 hover:ring-primary/30 hover:ring-inset",
+} as const;
+
+const fixTokenText = (text: string) => {
+    const numNewlines = (text.match(/\n/g) || []).length;
+    const result = text
+        .replace(/\r\n/g, "\\r\\n")
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/\t/g, "\\t");
+    return { result, numNewlines };
+};
+
+function TokenDisplay({ tokens, loading }: { tokens: Token[]; loading: boolean }) {
+    return (
+        <div className="w-full custom-scrollbar select-none whitespace-pre-wrap break-words">
+            {tokens.map((token, idx) => {
+                const { result, numNewlines } = fixTokenText(token.text);
+                return (
+                    <span key={`token-${idx}`}>
+                        <span
+                            data-token-id={idx}
+                            className={cn(
+                                TOKEN_STYLES.base,
+                                "bg-transparent",
+                                !loading && TOKEN_STYLES.hover,
+                                token.text === "\\n" ? "w-full" : "w-fit",
+                                loading ? "cursor-progress" : "cursor-default",
+                            )}
+                        >
+                            {result}
+                        </span>
+                        {numNewlines > 0 && "\n".repeat(numNewlines)}
+                    </span>
+                );
+            })}
+        </div>
+    );
+}
+
+export function JLensControls({
+    initialConfig,
+    selectedModel,
+    modelsAvailable,
+    modelsLoading = false,
+    hasExistingData = false,
+}: JLensControlsProps) {
+    const { workspaceId, chartId } = useParams<{ workspaceId: string; chartId: string }>();
+
+    const savedPrompt = initialConfig.data?.prompt || "";
+    const savedTopk = initialConfig.data?.topk ?? 5;
+    const savedIncludeEntropy = initialConfig.data?.includeEntropy ?? true;
+    const savedModel = initialConfig.data?.model ?? "";
+
+    const [prompt, setPrompt] = useState(savedPrompt);
+    const [topk, setTopk] = useState(savedTopk);
+    const [includeEntropy, setIncludeEntropy] = useState(savedIncludeEntropy);
+    const { draftModel, setDraftModel, restoreWorkspaceModel } = useDraftModel(
+        savedModel,
+        initialConfig.id,
+    );
+
+    const shouldAutoRunRef = useRef(savedPrompt.trim().length > 0 && !hasExistingData);
+    const hasAutoRunRef = useRef(false);
+
+    const [tokenData, setTokenData] = useState<Token[]>([]);
+    const [editingText, setEditingText] = useState(true);
+    const [tokenizedModel, setTokenizedModel] = useState<string | null>(null);
+
+    // Tokens of the saved prompt under (saved model, selected model). Both run
+    // in the background and are used only by the tokenization-differs banner.
+    // They never replace the visible `tokenData` — that change is gated by the
+    // banner's explicit "Update config to selected model" action.
+    const {
+        underSaved: savedPromptTokensUnderSavedModel,
+        underSelected: savedPromptTokensUnderSelectedModel,
+    } = useBackgroundTokenPair(savedPrompt, savedModel, selectedModel);
+
+    const lastSyncedPromptRef = useRef<string>(savedPrompt);
+    // The prompt that produced the current `tokenData`. Used by handleTokenize
+    // to detect a real prompt edit (vs. a passive blur that just re-tokenizes
+    // under a swapped model).
+    const lastTokenizedPromptRef = useRef<string>("");
+
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const tokenContainerRef = useRef<HTMLDivElement>(null);
+
+    const { mutateAsync: computeJLens, isPending: isComputing } = useJLens();
+    const { mutateAsync: updateConfig, isPending: isUpdatingConfig } = useUpdateChartConfig();
+
+    const isExecuting = isComputing || isUpdatingConfig;
+    const interactive = modelsAvailable && !isExecuting;
+
+    useEffect(() => {
+        const configPrompt = initialConfig.data?.prompt || "";
+        if (configPrompt && configPrompt !== lastSyncedPromptRef.current) {
+            setPrompt(configPrompt);
+            lastSyncedPromptRef.current = configPrompt;
+        }
+    }, [initialConfig.data?.prompt]);
+
+    // Auto-retokenize on selected-model change when the chart has no data
+    // yet. During initial composition the user has no committed visualization
+    // to protect, so swapping the global model selector should immediately
+    // re-tokenize under the new model and align draftModel — otherwise the
+    // Run button stays disabled and the explicit Sync action is hidden by
+    // its !hasExistingData guard.
+    useEffect(() => {
+        if (hasExistingData) return;
+        if (editingText) return; // user is mid-typing; blur will handle it
+        if (!prompt || !selectedModel) return;
+        if (tokenizedModel === selectedModel) return;
+        let cancelled = false;
+        encodeText(prompt, selectedModel)
+            .then((tokens) => {
+                if (cancelled || tokens.length === 0) return;
+                setTokenData(tokens);
+                setTokenizedModel(selectedModel);
+                lastTokenizedPromptRef.current = prompt;
+                setDraftModel(selectedModel);
+            })
+            .catch(() => {
+                /* tokenizer failure — leave editor open */
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [selectedModel, hasExistingData, editingText, prompt, tokenizedModel]);
+
+    // Initial-load tokenization for the visible token view. Uses the SAVED
+    // model — the one that produced the existing visualization — so switching
+    // the global model selector doesn't silently re-tokenize what the user is
+    // looking at. Only re-fires when the chart itself changes.
+    useEffect(() => {
+        const fetchTokens = async () => {
+            if (!savedPrompt || !savedModel) return;
+            try {
+                const tokens = await encodeText(savedPrompt, savedModel);
+                if (tokens.length > 0) {
+                    setTokenData(tokens);
+                    setTokenizedModel(savedModel);
+                    setEditingText(false);
+                    lastTokenizedPromptRef.current = savedPrompt;
+                }
+            } catch {
+                /* tokenizer load failure surfaces elsewhere; keep editor open */
+            }
+        };
+        fetchTokens();
+    }, [initialConfig.id, savedPrompt, savedModel]);
+
+    useEffect(() => {
+        let isCancelled = false;
+        const autoRunJLens = async () => {
+            if (
+                !shouldAutoRunRef.current ||
+                hasAutoRunRef.current ||
+                !selectedModel ||
+                !modelsAvailable
+            ) {
+                return;
+            }
+            hasAutoRunRef.current = true;
+            shouldAutoRunRef.current = false;
+            try {
+                // Same trim as handleSubmit — the auto-run path (landing page /
+                // auto-run on open) is a second submit path and must not send a
+                // trailing-space prompt either.
+                const trimmedPrompt = savedPrompt.trim();
+                const tokens = await encodeText(trimmedPrompt, selectedModel);
+                if (isCancelled || tokens.length <= 1) return;
+                setTokenData(tokens);
+                setTokenizedModel(selectedModel);
+                setEditingText(false);
+                // Keep the textarea state aligned with the trimmed value so
+                // tokensInSync (which compares against `prompt`) and the Run
+                // button stay correct after auto-run.
+                setPrompt(trimmedPrompt);
+                lastTokenizedPromptRef.current = trimmedPrompt;
+                const config: JLensConfigData = {
+                    model: selectedModel,
+                    prompt: trimmedPrompt,
+                    topk: savedTopk,
+                    includeEntropy: savedIncludeEntropy,
+                };
+                await computeJLens({
+                    lensRequest: { completion: config, chartId },
+                    configId: initialConfig.id,
+                });
+                if (isCancelled) return;
+                await updateConfig({
+                    configId: initialConfig.id,
+                    chartId,
+                    config: { data: config, workspaceId, type: "jlens" },
+                });
+                if (isCancelled) return;
+                lastSyncedPromptRef.current = trimmedPrompt;
+            } catch {
+                /* one-shot auto-run; swallow */
+            }
+        };
+        const timer = setTimeout(autoRunJLens, 800);
+        return () => {
+            isCancelled = true;
+            clearTimeout(timer);
+        };
+    }, [
+        selectedModel,
+        modelsAvailable,
+        savedPrompt,
+        savedTopk,
+        savedIncludeEntropy,
+        chartId,
+        initialConfig.id,
+        workspaceId,
+        computeJLens,
+        updateConfig,
+    ]);
+
+    const autoResizeTextarea = useCallback(() => {
+        if (textareaRef.current) {
+            textareaRef.current.style.height = "auto";
+            textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+        }
+    }, []);
+
+    useEffect(() => {
+        if (editingText) autoResizeTextarea();
+    }, [prompt, editingText, autoResizeTextarea]);
+
+    const escapeTokenArea = useCallback(() => {
+        setEditingText(true);
+        setTimeout(() => {
+            if (textareaRef.current) {
+                textareaRef.current.focus();
+                const length = textareaRef.current.value.length;
+                textareaRef.current.setSelectionRange(length, length);
+            }
+        }, 0);
+    }, []);
+
+    const handleTokenize = useCallback(async () => {
+        if (!prompt.trim()) {
+            toast.error("Please enter a prompt.");
+            return;
+        }
+        let tokens: Token[];
+        try {
+            tokens = await encodeText(prompt, selectedModel);
+        } catch (error) {
+            if (error instanceof TokenizerLoadError) {
+                toast.error(
+                    `Could not load tokenizer for ${selectedModel}. The model may be gated and require authentication.`,
+                );
+            } else {
+                toast.error("Failed to tokenize prompt.");
+            }
+            return;
+        }
+        if (tokens.length <= 1) {
+            toast.error("Please enter a longer prompt.");
+            return;
+        }
+        const promptChanged = prompt !== lastTokenizedPromptRef.current;
+        const modelChanged = tokenizedModel !== null && tokenizedModel !== selectedModel;
+        setTokenData(tokens);
+        setTokenizedModel(selectedModel);
+        setEditingText(false);
+        lastTokenizedPromptRef.current = prompt;
+        // Editing the prompt under a different selected model implicitly
+        // commits the draft to that model — same effect as the explicit
+        // "Update config to selected model" action. topk/includeEntropy are
+        // intentionally NOT touched here; only the Reset button resets them.
+        if (promptChanged && modelChanged) {
+            setDraftModel(selectedModel);
+        }
+    }, [prompt, selectedModel, tokenizedModel]);
+
+    const handleSubmit = useCallback(async () => {
+        // Trim surrounding whitespace: a trailing space tokenizes as its own
+        // token and collapses the model's prediction onto whitespace/digits.
+        const trimmedPrompt = prompt.trim();
+        if (!trimmedPrompt) return;
+        let tokens: Token[];
+        try {
+            tokens = await encodeText(trimmedPrompt, selectedModel);
+        } catch (error) {
+            if (error instanceof TokenizerLoadError) {
+                toast.error(
+                    `Could not load tokenizer for ${selectedModel}. The model may be gated and require authentication.`,
+                );
+            } else {
+                toast.error("Failed to tokenize prompt.");
+            }
+            return;
+        }
+        if (tokens.length <= 1) {
+            toast.error("Please enter a longer prompt.");
+            return;
+        }
+        setTokenData(tokens);
+        setTokenizedModel(selectedModel);
+        lastTokenizedPromptRef.current = trimmedPrompt;
+
+        const config: JLensConfigData = {
+            model: selectedModel,
+            prompt: trimmedPrompt,
+            topk,
+            includeEntropy,
+        };
+
+        await computeJLens({
+            lensRequest: { completion: config, chartId },
+            configId: initialConfig.id,
+        });
+        await updateConfig({
+            configId: initialConfig.id,
+            chartId,
+            config: { data: config, workspaceId, type: "jlens" },
+        });
+        // Land draftModel on the model that just persisted so the banner
+        // doesn't flash between the run completing and the refetch arriving.
+        setDraftModel(selectedModel);
+        lastSyncedPromptRef.current = trimmedPrompt;
+        setEditingText(false);
+    }, [
+        prompt,
+        topk,
+        includeEntropy,
+        selectedModel,
+        chartId,
+        initialConfig.id,
+        workspaceId,
+        computeJLens,
+        updateConfig,
+    ]);
+
+    const handlePromptChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setPrompt(e.target.value);
+    }, []);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                handleSubmit();
+            }
+        },
+        [handleSubmit],
+    );
+
+    const blurTokenize = useBlurTokenizeScheduler();
+
+    const handleTextareaBlur = useCallback(() => {
+        blurTokenize.schedule(() => {
+            const activeElement = document.activeElement;
+            const withinTextarea = activeElement && textareaRef.current?.contains(activeElement);
+            const withinToken = activeElement && tokenContainerRef.current?.contains(activeElement);
+            const popoverOpen = document.querySelector("[data-radix-popper-content-wrapper]");
+            if (withinTextarea || withinToken || popoverOpen) return;
+            if (prompt.trim()) handleTokenize();
+        });
+    }, [prompt, handleTokenize, blurTokenize]);
+
+    const resetDraft = useCallback(() => {
+        blurTokenize.cancel();
+        setPrompt(savedPrompt);
+        setTopk(savedTopk);
+        setIncludeEntropy(savedIncludeEntropy);
+        setDraftModel(savedModel);
+        restoreWorkspaceModel(savedModel);
+        lastSyncedPromptRef.current = savedPrompt;
+
+        // Re-tokenize the restored prompt under the saved model so the
+        // visible token view matches the restored config.
+        if (!savedPrompt || !savedModel) return;
+        encodeText(savedPrompt, savedModel)
+            .then((tokens) => {
+                if (tokens.length > 0) {
+                    setTokenData(tokens);
+                    setTokenizedModel(savedModel);
+                    setEditingText(false);
+                    lastTokenizedPromptRef.current = savedPrompt;
+                }
+            })
+            .catch(() => {
+                /* user can manually retokenize */
+            });
+    }, [
+        savedPrompt,
+        savedTopk,
+        savedIncludeEntropy,
+        savedModel,
+        blurTokenize,
+        setDraftModel,
+        restoreWorkspaceModel,
+    ]);
+
+    // Acknowledge "use the selected model for this chart". Local-only — the
+    // DB row is unchanged until the user clicks Run. Also re-tokenizes the
+    // visible prompt under the new model so the user can see the difference.
+    const updateConfigModel = useCallback(() => {
+        if (!selectedModel) return;
+        blurTokenize.cancel();
+        setDraftModel(selectedModel);
+        if (!prompt) return;
+        encodeText(prompt, selectedModel)
+            .then((tokens) => {
+                if (tokens.length > 0) {
+                    setTokenData(tokens);
+                    setTokenizedModel(selectedModel);
+                    setEditingText(false);
+                    lastTokenizedPromptRef.current = prompt;
+                }
+            })
+            .catch(() => {
+                /* user can manually retokenize */
+            });
+    }, [selectedModel, prompt, blurTokenize, setDraftModel]);
+
+    // --- diff state -----------------------------------------------------------
+
+    const draftMatchesSaved = useMemo(
+        () =>
+            jlensConfigEqualsExceptModel(initialConfig.data, {
+                prompt,
+                topk,
+                includeEntropy,
+            }),
+        [initialConfig.data, prompt, topk, includeEntropy],
+    );
+
+    // Draft is dirty if any non-model field differs OR the draft model differs
+    // from the saved model. Either way, the Unsaved-changes banner fires.
+    const draftDirty = !draftMatchesSaved || draftModel !== savedModel;
+
+    // The "use selected model?" banner is about the gap between the user's
+    // current intent for this chart (draftModel) and the workspace selection.
+    const modelMismatchVsConfig = modelsAvailable && !!draftModel && draftModel !== selectedModel;
+
+    const tokenizationDiffers = useMemo(() => {
+        if (!modelMismatchVsConfig) return false;
+        if (!savedPromptTokensUnderSavedModel || !savedPromptTokensUnderSelectedModel) {
+            return false;
+        }
+        return !tokenTextSequencesEqual(
+            savedPromptTokensUnderSavedModel,
+            savedPromptTokensUnderSelectedModel,
+        );
+    }, [
+        modelMismatchVsConfig,
+        savedPromptTokensUnderSavedModel,
+        savedPromptTokensUnderSelectedModel,
+    ]);
+
+    // Title-row action visibility (see handoff §3).
+    const showReset = draftDirty && hasExistingData;
+    const showSync = modelMismatchVsConfig;
+    const viewMode = !modelsAvailable && !modelsLoading;
+
+    // Run is only enabled when the visible tokens (a) were produced by the
+    // selected model and (b) correspond to the current prompt — i.e. there
+    // are no pending edits or model swaps waiting on retokenization.
+    const tokensInSync =
+        tokenData.length > 0 &&
+        tokenizedModel === selectedModel &&
+        lastTokenizedPromptRef.current === prompt;
+
+    return (
+        <>
+            <ToolPanelHeader
+                title="J-Lens"
+                viewMode={viewMode}
+                showReset={showReset}
+                showSync={showSync}
+                isExecuting={isExecuting}
+                onReset={resetDraft}
+                onSync={updateConfigModel}
+            />
+            <div className="p-3 flex-1 overflow-auto flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                    <Label className="text-sm font-medium">Prompt</Label>
+                    <div className="relative">
+                        {editingText ? (
+                            <Textarea
+                                ref={textareaRef}
+                                value={prompt}
+                                onChange={(e) => {
+                                    handlePromptChange(e);
+                                    autoResizeTextarea();
+                                }}
+                                onKeyDown={handleKeyDown}
+                                onBlur={handleTextareaBlur}
+                                className="w-full !text-sm bg-input/30 min-h-32 !leading-5"
+                                placeholder="Enter your prompt here..."
+                                disabled={!interactive}
+                            />
+                        ) : (
+                            <div
+                                ref={tokenContainerRef}
+                                className={cn(
+                                    "flex w-full px-3 py-2 bg-input/30 border rounded min-h-32",
+                                    isExecuting ? "cursor-progress" : "cursor-text",
+                                )}
+                                onClick={() => {
+                                    if (interactive) escapeTokenArea();
+                                }}
+                            >
+                                <TokenDisplay tokens={tokenData} loading={isExecuting} />
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between">
+                        <Label htmlFor="topk" className="text-sm font-medium">
+                            Top-K Predictions
+                        </Label>
+                        <span className="text-sm text-muted-foreground">{topk}</span>
+                    </div>
+                    <Slider
+                        id="topk"
+                        min={1}
+                        max={10}
+                        step={1}
+                        value={[topk]}
+                        onValueChange={([value]) => setTopk(value)}
+                        disabled={!interactive}
+                        className="w-full"
+                    />
+                </div>
+
+                <div className="flex items-center gap-2">
+                    <Checkbox
+                        id="entropy"
+                        checked={includeEntropy}
+                        onCheckedChange={(checked) => setIncludeEntropy(checked === true)}
+                        disabled={!interactive}
+                    />
+                    <Label htmlFor="entropy" className="text-sm font-medium cursor-pointer">
+                        Include Entropy
+                    </Label>
+                </div>
+
+                <Button
+                    onClick={handleSubmit}
+                    disabled={!interactive || !prompt.trim() || !tokensInSync}
+                    className="w-full"
+                >
+                    {isExecuting ? (
+                        <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Computing...
+                        </>
+                    ) : (
+                        <>
+                            <Play className="mr-2 h-4 w-4" />
+                            Run J-Lens
+                        </>
+                    )}
+                </Button>
+
+                <p className="text-xs text-muted-foreground text-center">
+                    <kbd className="px-1 py-0.5 bg-muted rounded text-xs">⌘</kbd> +{" "}
+                    <kbd className="px-1 py-0.5 bg-muted rounded text-xs">Enter</kbd> to run
+                </p>
+            </div>
+        </>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensDisplay.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensDisplay.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useParams } from "next/navigation";
+import { useQuery, useIsMutating } from "@tanstack/react-query";
+import { getChartById, getConfigForChart } from "@/lib/queries/chartQueries";
+import { queryKeys } from "@/lib/queryKeys";
+import { JLensData, JLensConfigData } from "@/types/jlens";
+import { useTheme } from "next-themes";
+import { Loader2 } from "lucide-react";
+import { LogitLensWidget } from "nnsightful";
+import type { LogitLensData, LogitLensUIState } from "nnsightful";
+import { useModelsQuery } from "@/lib/api/modelsApi";
+import { useWorkspace } from "@/stores/useWorkspace";
+import { useUpdateChartName } from "@/lib/api/chartApi";
+import { useUpdateChartConfig } from "@/lib/api/configApi";
+import { ChartModelPill } from "@/components/charts/ChartModelPill";
+import { chartModelFromConfig, isChartStale } from "@/lib/configModelDiff";
+
+interface JLensChart {
+    id: string;
+    data: JLensData | null;
+    type: string;
+    name?: string;
+}
+
+interface JLensConfig {
+    id: string;
+    data: JLensConfigData;
+    type: string;
+}
+
+export function JLensDisplay() {
+    const { chartId, workspaceId } = useParams<{ chartId: string; workspaceId: string }>();
+    const { resolvedTheme } = useTheme();
+    const isDarkMode = resolvedTheme === "dark";
+
+    const isJLensRunning = useIsMutating({ mutationKey: ["jlens"] }) > 0;
+
+    const [localTitle, setLocalTitle] = useState<string | null>(null); // null → use chart name
+    const [isEditingTitle, setIsEditingTitle] = useState(false);
+    const titleInputRef = useRef<HTMLInputElement>(null);
+    const saveTitleTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    const { data: chart, isLoading } = useQuery({
+        queryKey: queryKeys.charts.chart(chartId),
+        queryFn: () => getChartById(chartId as string),
+        enabled: !!chartId,
+    });
+
+    const { data: config } = useQuery({
+        queryKey: queryKeys.charts.configByChart(chartId),
+        queryFn: () => getConfigForChart(chartId),
+        enabled: !!chartId,
+    });
+
+    const { data: models } = useModelsQuery();
+
+    const { selectedModelIdx } = useWorkspace();
+    const selectedModel = models?.[selectedModelIdx]?.name ?? models?.[0]?.name ?? null;
+    const modelsAvailable = !!models && models.length > 0;
+
+    const { mutate: updateChartName } = useUpdateChartName();
+    const { mutate: updateChartConfig } = useUpdateChartConfig();
+
+    const jlensChart = chart as JLensChart | undefined;
+    const jlensConfig = config as JLensConfig | undefined;
+    const hasData = jlensChart?.data && "meta" in jlensChart.data;
+
+    // ── Persist heatmap UI state (pins, selection, layer window, appearance)
+    // into the chart config, mirroring Lens2Display. Debounced because the
+    // widget emits on every interaction; restored on mount via the `uiState`
+    // prop below.
+    const savedUiState = jlensConfig?.data?.uiState as LogitLensUIState | undefined;
+    const jlensConfigRef = useRef(jlensConfig);
+    jlensConfigRef.current = jlensConfig;
+    const saveUiStateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    const handleStateChange = useCallback(
+        (uiState: LogitLensUIState) => {
+            if (saveUiStateTimeoutRef.current) clearTimeout(saveUiStateTimeoutRef.current);
+            saveUiStateTimeoutRef.current = setTimeout(() => {
+                const cfg = jlensConfigRef.current;
+                if (!cfg?.id) return;
+                updateChartConfig({
+                    configId: cfg.id,
+                    chartId,
+                    config: {
+                        data: { ...cfg.data, uiState },
+                        workspaceId,
+                        type: "jlens",
+                    },
+                });
+            }, 500);
+        },
+        [chartId, workspaceId, updateChartConfig],
+    );
+
+    useEffect(() => {
+        return () => {
+            if (saveUiStateTimeoutRef.current) clearTimeout(saveUiStateTimeoutRef.current);
+        };
+    }, []);
+
+    const chartModel = chartModelFromConfig(jlensConfig, jlensChart);
+    const stale = isChartStale(chartModel, selectedModel, modelsAvailable);
+
+    // Chart title — mirrors Lens2Display. "Untitled Chart" is the stored
+    // default and treated as empty for display purposes.
+    const rawChartName = jlensChart?.name || "";
+    const chartName = rawChartName === "Untitled Chart" ? "" : rawChartName;
+    const displayTitle = localTitle !== null ? localTitle : chartName;
+    const hasTitle = displayTitle.trim().length > 0 && displayTitle.trim() !== "Untitled Chart";
+
+    // Reset local title when the chart changes.
+    useEffect(() => {
+        setLocalTitle(null);
+        setIsEditingTitle(false);
+    }, [chartId]);
+
+    // Debounced save; don't reset localTitle here to avoid flicker (it syncs
+    // on chart change).
+    const saveTitle = useCallback(
+        (newTitle: string) => {
+            if (!chartId) return;
+            if (saveTitleTimeoutRef.current) clearTimeout(saveTitleTimeoutRef.current);
+            saveTitleTimeoutRef.current = setTimeout(() => {
+                updateChartName({ chartId, name: newTitle });
+            }, 500);
+        },
+        [chartId, updateChartName],
+    );
+
+    const handleTitleChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const newTitle = e.target.value;
+            setLocalTitle(newTitle);
+            saveTitle(newTitle);
+        },
+        [saveTitle],
+    );
+
+    const handleTitleBlur = useCallback(() => setIsEditingTitle(false), []);
+
+    const handleTitleClick = useCallback(() => {
+        setLocalTitle(displayTitle);
+        setIsEditingTitle(true);
+        setTimeout(() => {
+            titleInputRef.current?.focus();
+            titleInputRef.current?.select();
+        }, 0);
+    }, [displayTitle]);
+
+    if (isLoading) {
+        return (
+            <div className="flex size-full items-center justify-center">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+        );
+    }
+
+    if (isJLensRunning) {
+        return (
+            <div className="flex size-full items-center justify-center flex-col gap-4">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                <p className="text-muted-foreground">Computing j-lens visualization...</p>
+            </div>
+        );
+    }
+
+    if (!hasData) {
+        return (
+            <div className="flex size-full items-center justify-center border mx-3 mt-3 border-dashed rounded pb-6">
+                <div className="text-muted-foreground text-center">
+                    <p>No visualization data</p>
+                    <p className="text-sm mt-2">
+                        Enter a prompt and click &quot;Run J-Lens&quot; to visualize
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="size-full overflow-auto p-4 flex flex-col gap-3">
+            {/* Title + model pill */}
+            <div className="flex items-center gap-2">
+                <div className="min-w-0 flex-1">
+                    {isEditingTitle ? (
+                        <input
+                            ref={titleInputRef}
+                            type="text"
+                            value={displayTitle}
+                            onChange={handleTitleChange}
+                            onBlur={handleTitleBlur}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") e.currentTarget.blur();
+                            }}
+                            placeholder="Untitled Chart"
+                            className="w-full text-lg font-semibold bg-transparent border-none outline-none focus:ring-0 placeholder:text-muted-foreground/50"
+                        />
+                    ) : hasTitle ? (
+                        <h2
+                            onClick={handleTitleClick}
+                            className="cursor-text hover:bg-accent/30 rounded px-1 -mx-1 py-0.5 transition-colors text-lg font-semibold truncate"
+                        >
+                            {displayTitle}
+                        </h2>
+                    ) : (
+                        <h2
+                            onClick={handleTitleClick}
+                            className="cursor-text hover:bg-accent/30 rounded px-1 -mx-1 py-0.5 transition-colors text-lg font-medium text-gray-400"
+                        >
+                            Untitled Chart
+                        </h2>
+                    )}
+                </div>
+                {stale && chartModel && <ChartModelPill modelName={chartModel} />}
+            </div>
+            <LogitLensWidget
+                data={jlensChart.data! as LogitLensData}
+                darkMode={isDarkMode}
+                uiState={savedUiState}
+                onStateChange={handleStateChange}
+                className="w-full min-h-[400px]"
+            />
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensDisplay.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/components/JLensDisplay.tsx
@@ -16,6 +16,7 @@ import { useUpdateChartName } from "@/lib/api/chartApi";
 import { useUpdateChartConfig } from "@/lib/api/configApi";
 import { ChartModelPill } from "@/components/charts/ChartModelPill";
 import { chartModelFromConfig, isChartStale } from "@/lib/configModelDiff";
+import { isToolSupportedForModel } from "@/lib/toolSupport";
 
 interface JLensChart {
     id: string;
@@ -57,8 +58,12 @@ export function JLensDisplay() {
     const { data: models } = useModelsQuery();
 
     const { selectedModelIdx } = useWorkspace();
-    const selectedModel = models?.[selectedModelIdx]?.name ?? models?.[0]?.name ?? null;
+    const selectedModelObj = models?.[selectedModelIdx] ?? models?.[0];
+    const selectedModel = selectedModelObj?.name ?? null;
     const modelsAvailable = !!models && models.length > 0;
+    // Whether the currently-selected model can run j-lens. Only meaningful for
+    // the empty-state prompt; a saved result always renders regardless.
+    const modelSupported = !selectedModelObj || isToolSupportedForModel("jlens", selectedModelObj);
 
     const { mutate: updateChartName } = useUpdateChartName();
     const { mutate: updateChartConfig } = useUpdateChartConfig();
@@ -172,10 +177,21 @@ export function JLensDisplay() {
         return (
             <div className="flex size-full items-center justify-center border mx-3 mt-3 border-dashed rounded pb-6">
                 <div className="text-muted-foreground text-center">
-                    <p>No visualization data</p>
-                    <p className="text-sm mt-2">
-                        Enter a prompt and click &quot;Run J-Lens&quot; to visualize
-                    </p>
+                    {modelSupported ? (
+                        <>
+                            <p>No visualization data</p>
+                            <p className="text-sm mt-2">
+                                Enter a prompt and click &quot;Run J-Lens&quot; to visualize
+                            </p>
+                        </>
+                    ) : (
+                        <>
+                            <p>J-Lens isn&apos;t available for this model</p>
+                            <p className="text-sm mt-2">
+                                Select a model with a Jacobian lens from the header to run J-Lens.
+                            </p>
+                        </>
+                    )}
                 </div>
             </div>
         );

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/page.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/page.tsx
@@ -10,7 +10,7 @@ import { MobileSidebarDrawer } from "../../components/MobileSidebarDrawer";
 import { MobileCollapsibleControls } from "../../components/MobileCollapsibleControls";
 import { ModelDeployingPanel } from "../../components/ModelDeployingPanel";
 import { useChartModelReady } from "@/hooks/useChartModelReady";
-import { Layers3 } from "lucide-react";
+import { JLensIcon } from "@/components/JLensIcon";
 import { useIsMutating } from "@tanstack/react-query";
 
 export default function JLensChartPage() {
@@ -41,7 +41,7 @@ export default function JLensChartPage() {
                     <>
                         <MobileCollapsibleControls
                             label="J-Lens"
-                            icon={Layers3}
+                            icon={JLensIcon}
                             isRunning={isRunning}
                         >
                             <JLensArea />

--- a/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/page.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/j-lens/[chartId]/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import ChartCardsSidebar from "../../components/ChartCardsSidebar";
+import JLensArea from "./components/JLensArea";
+import { JLensDisplay } from "./components/JLensDisplay";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { MobileSidebarDrawer } from "../../components/MobileSidebarDrawer";
+import { MobileCollapsibleControls } from "../../components/MobileCollapsibleControls";
+import { ModelDeployingPanel } from "../../components/ModelDeployingPanel";
+import { useChartModelReady } from "@/hooks/useChartModelReady";
+import { Layers3 } from "lucide-react";
+import { useIsMutating } from "@tanstack/react-query";
+
+export default function JLensChartPage() {
+    const isMobile = useIsMobile();
+    const isRunning = useIsMutating({ mutationKey: ["jlens"] }) > 0;
+    const { chartId } = useParams<{ chartId: string }>();
+    const readiness = useChartModelReady(chartId);
+
+    if (isMobile === undefined) return null;
+
+    // Model not yet deployed AND no saved result → show the deploying panel in
+    // place of the controls/visualization. The chart sidebar (desktop) and
+    // drawer (mobile) stay mounted so the user can navigate to other charts
+    // while this model deploys.
+    const deploying = readiness.state === "deploying";
+
+    if (isMobile) {
+        return (
+            <div className="size-full flex flex-col min-h-0 overflow-auto p-2 pb-20 gap-2">
+                {deploying ? (
+                    <div className="rounded dark:bg-secondary/50 bg-secondary/80 border min-h-[50vh] flex-1">
+                        <ModelDeployingPanel
+                            modelName={readiness.modelName}
+                            phase={readiness.phase}
+                        />
+                    </div>
+                ) : (
+                    <>
+                        <MobileCollapsibleControls
+                            label="J-Lens"
+                            icon={Layers3}
+                            isRunning={isRunning}
+                        >
+                            <JLensArea />
+                        </MobileCollapsibleControls>
+                        <div className="rounded dark:bg-secondary/50 bg-secondary/80 border min-h-[50vh] flex-1">
+                            <JLensDisplay />
+                        </div>
+                    </>
+                )}
+                <MobileSidebarDrawer />
+            </div>
+        );
+    }
+
+    return (
+        <div className="size-full flex min-h-0">
+            <ChartCardsSidebar />
+            <div className="flex-1 min-h-0 pb-3 pr-3">
+                {deploying ? (
+                    <div className="size-full rounded dark:bg-secondary/50 bg-secondary/80 border">
+                        <ModelDeployingPanel
+                            modelName={readiness.modelName}
+                            phase={readiness.phase}
+                        />
+                    </div>
+                ) : (
+                    <ResizablePanelGroup
+                        direction="horizontal"
+                        className="flex size-full rounded dark:bg-secondary/50 bg-secondary/80 border"
+                    >
+                        <ResizablePanel className="h-full" defaultSize={25} minSize={20}>
+                            <JLensArea />
+                        </ResizablePanel>
+                        <ResizableHandle className="w-[0.8px]" />
+                        <ResizablePanel defaultSize={75} minSize={40}>
+                            <JLensDisplay />
+                        </ResizablePanel>
+                    </ResizablePanelGroup>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/workbench/_web/src/app/workbench/[workspaceId]/lens2/[chartId]/components/Lens2Controls.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/lens2/[chartId]/components/Lens2Controls.tsx
@@ -548,6 +548,10 @@ export function Lens2Controls({
         <>
             <ToolPanelHeader
                 title="Logit Lens"
+                reference={{
+                    href: "https://www.lesswrong.com/posts/AcKRB8wDpdaN6v6ru/interpreting-gpt-the-logit-lens",
+                    label: "Logit Lens reference (lesswrong.com)",
+                }}
                 viewMode={viewMode}
                 showReset={showReset}
                 showSync={showSync}

--- a/workbench/_web/src/app/workbench/[workspaceId]/page.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/page.tsx
@@ -50,6 +50,8 @@ export default async function Page({
     // Redirect to the appropriate chart route based on type
     if (chartType === "lens2") {
         redirect(`/workbench/${workspaceId}/lens2/${chart.id}`);
+    } else if (chartType === "jlens") {
+        redirect(`/workbench/${workspaceId}/j-lens/${chart.id}`);
     } else if (chartType === "activation-patching") {
         redirect(`/workbench/${workspaceId}/activation-patching/${chart.id}`);
     } else if (chartType === "patch-lens") {

--- a/workbench/_web/src/app/workbench/components/AutoWorkspaceCreator.tsx
+++ b/workbench/_web/src/app/workbench/components/AutoWorkspaceCreator.tsx
@@ -120,7 +120,10 @@ export function AutoWorkspaceCreator({
                             topk: 5,
                             includeEntropy: true,
                         };
-                        const { chart } = await createJLensChartPair(targetWorkspaceId, jlensConfig);
+                        const { chart } = await createJLensChartPair(
+                            targetWorkspaceId,
+                            jlensConfig,
+                        );
                         userChartId = chart.id;
                         chartType = "jlens";
                     } else {
@@ -162,7 +165,12 @@ export function AutoWorkspaceCreator({
                     userChartId = chart.id;
                     chartType = "activation-patching";
                     console.log("Created activation patching chart:", userChartId);
-                } else if (tool === "J-Lens" && initialPrompt && initialPrompt.trim() && initialModel) {
+                } else if (
+                    tool === "J-Lens" &&
+                    initialPrompt &&
+                    initialPrompt.trim() &&
+                    initialModel
+                ) {
                     console.log("Creating j-lens chart for user prompt:", initialPrompt);
                     const jlensChartConfig: JLensConfigData = {
                         prompt: initialPrompt,

--- a/workbench/_web/src/app/workbench/components/AutoWorkspaceCreator.tsx
+++ b/workbench/_web/src/app/workbench/components/AutoWorkspaceCreator.tsx
@@ -7,12 +7,14 @@ import { createWorkspace } from "@/lib/queries/workspaceQueries";
 // import { pushTutorialChart } from "@/lib/queries/tutorialChart";
 import {
     createLens2ChartPair,
+    createJLensChartPair,
     createActivationPatchingChartPair,
 } from "@/lib/queries/chartQueries";
 import { queryKeys } from "@/lib/queryKeys";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { Lens2ConfigData } from "@/types/lens2";
+import type { JLensConfigData } from "@/types/jlens";
 import type { ActivationPatchingConfigData, SourcePosition } from "@/types/activationPatching";
 
 interface AutoWorkspaceCreatorProps {
@@ -111,6 +113,16 @@ export function AutoWorkspaceCreator({
                         );
                         userChartId = chart.id;
                         chartType = "activation-patching";
+                    } else if (tool === "J-Lens") {
+                        const jlensConfig: JLensConfigData = {
+                            model,
+                            prompt: "",
+                            topk: 5,
+                            includeEntropy: true,
+                        };
+                        const { chart } = await createJLensChartPair(targetWorkspaceId, jlensConfig);
+                        userChartId = chart.id;
+                        chartType = "jlens";
                     } else {
                         const lensConfig: Lens2ConfigData = {
                             model,
@@ -150,6 +162,22 @@ export function AutoWorkspaceCreator({
                     userChartId = chart.id;
                     chartType = "activation-patching";
                     console.log("Created activation patching chart:", userChartId);
+                } else if (tool === "J-Lens" && initialPrompt && initialPrompt.trim() && initialModel) {
+                    console.log("Creating j-lens chart for user prompt:", initialPrompt);
+                    const jlensChartConfig: JLensConfigData = {
+                        prompt: initialPrompt,
+                        model: initialModel,
+                        topk: 5,
+                        includeEntropy: true,
+                    };
+
+                    const { chart } = await createJLensChartPair(
+                        targetWorkspaceId,
+                        jlensChartConfig,
+                    );
+                    userChartId = chart.id;
+                    chartType = "jlens";
+                    console.log("Created user j-lens chart:", userChartId);
                 } else if (initialPrompt && initialPrompt.trim() && initialModel) {
                     console.log("Creating lens2 chart for user prompt:", initialPrompt);
                     const userChartConfig: Lens2ConfigData = {
@@ -185,6 +213,8 @@ export function AutoWorkspaceCreator({
                             router.push(
                                 `/workbench/${targetWorkspaceId}/activation-patching/${userChartId}`,
                             );
+                        } else if (chartType === "jlens") {
+                            router.push(`/workbench/${targetWorkspaceId}/j-lens/${userChartId}`);
                         } else {
                             router.push(`/workbench/${targetWorkspaceId}/lens2/${userChartId}`);
                         }

--- a/workbench/_web/src/components/JLensIcon.tsx
+++ b/workbench/_web/src/components/JLensIcon.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+/**
+ * J-Lens tool icon: the letter "J" beside a magnifying glass (the "lens", drawn
+ * as Lucide's Search glyph — a circle + handle). Rendered in Lucide's style
+ * (24×24, currentColor stroke, round caps/joins) so it sits cleanly beside the
+ * other tool icons and sizes via Tailwind `h-*`/`w-*` classes.
+ */
+export function JLensIcon({ className }: { className?: string }) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+            aria-hidden="true"
+        >
+            {/* "J" */}
+            <path d="M3 4h4.5" />
+            <path d="M6 4v8a2.5 2.5 0 0 1-2.5 2.5" />
+            {/* lens (magnifying glass) */}
+            <circle cx="15" cy="10" r="5" />
+            <path d="m18.5 13.5 2.5 2.5" />
+        </svg>
+    );
+}

--- a/workbench/_web/src/components/LandingPage.tsx
+++ b/workbench/_web/src/components/LandingPage.tsx
@@ -25,6 +25,8 @@ import {
 } from "@/components/selectors/LaunchSelectors";
 import { cn } from "@/lib/utils";
 import PromptVisualization from "@/components/PromptVisualization";
+import { JLensIcon } from "@/components/JLensIcon";
+import { SparkBadge } from "@/components/SparkBadge";
 import type { Model, Token } from "@/types/models";
 import type { SourcePosition } from "@/types/activationPatching";
 import type { ToolType } from "@/types/charts";
@@ -229,6 +231,10 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
     const [selectedTool, setSelectedTool] = useState<string>("Logit Lens");
     const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
     const captchaRef = useRef<ElementRef<typeof HCaptcha> | null>(null);
+    // A prebuilt `/workbench?…` query to redirect to after anonymous sign-in.
+    // Set by the one-click launches (e.g. Discover J-Lens) that don't go through
+    // the prompt form; null → fall back to building params from the form state.
+    const pendingLaunchRef = useRef<string | null>(null);
     const router = useRouter();
 
     // Activation patching state
@@ -297,36 +303,43 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
                 setShowCaptcha(false);
                 captchaRef.current?.resetCaptcha();
                 setIsSubmitting(false);
+                pendingLaunchRef.current = null;
             } else {
-                // Redirect to workbench with the prompt and model as query parameters
-                const params = new URLSearchParams({
-                    model: selectedModel,
-                    tool: selectedTool,
-                });
+                // A one-click launch (Discover J-Lens) prebuilt its target;
+                // otherwise build from the prompt-form state.
+                let qs = pendingLaunchRef.current;
+                if (!qs) {
+                    const params = new URLSearchParams({
+                        model: selectedModel,
+                        tool: selectedTool,
+                    });
 
-                if (selectedTool === "Activation Patching") {
-                    params.set("srcPrompt", srcPrompt);
-                    params.set("tgtPrompt", tgtPrompt);
-                    params.set("srcPos", JSON.stringify(srcPos));
-                    params.set("tgtPos", JSON.stringify(tgtPos));
-                    if (tgtFreeze.length > 0) {
-                        params.set("tgtFreeze", JSON.stringify(tgtFreeze));
+                    if (selectedTool === "Activation Patching") {
+                        params.set("srcPrompt", srcPrompt);
+                        params.set("tgtPrompt", tgtPrompt);
+                        params.set("srcPos", JSON.stringify(srcPos));
+                        params.set("tgtPos", JSON.stringify(tgtPos));
+                        if (tgtFreeze.length > 0) {
+                            params.set("tgtFreeze", JSON.stringify(tgtFreeze));
+                        }
+                    } else {
+                        params.set("prompt", prompt);
                     }
-                } else {
-                    params.set("prompt", prompt);
-                }
 
-                if (selectedWorkspace && selectedWorkspace !== "new") {
-                    params.set("workspaceId", selectedWorkspace);
+                    if (selectedWorkspace && selectedWorkspace !== "new") {
+                        params.set("workspaceId", selectedWorkspace);
+                    }
+                    qs = params.toString();
                 }
-
-                window.location.href = `/workbench?${params.toString()}`;
+                pendingLaunchRef.current = null;
+                window.location.href = `/workbench?${qs}`;
             }
         } catch (err) {
             console.error("Anonymous sign-in error:", err);
             setShowCaptcha(false);
             captchaRef.current?.resetCaptcha();
             setIsSubmitting(false);
+            pendingLaunchRef.current = null;
         }
     };
 
@@ -405,6 +418,48 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
             router.push(`/workbench?${params.toString()}`);
         } else {
             // Show captcha for anonymous/non-logged-in users
+            setShowCaptcha(true);
+        }
+    };
+
+    // One-click launch of the new J-Lens tool: pick a J-Lens-supported model
+    // (the one already selected if it qualifies, else the best available hot
+    // one), then run the normal workspace-creation pipeline with no prompt —
+    // signing in anonymously first if the visitor isn't authenticated.
+    const handleDiscoverJLens = () => {
+        // "Usable" = the current user can actually run it: supports j-lens AND
+        // is allowed for this session. `allowed` is false for gated models when
+        // signed out, so this never lands an anonymous user on a gated model
+        // (which the deploy flow can't handle — it has no /login gate).
+        const usable = (m: Model) => m.allowed && isToolSupportedForModel("jlens", m);
+        const current = modelsToSelect.find((m) => m.name === selectedModel);
+        const model =
+            current && usable(current)
+                ? current
+                : (modelsToSelect.find((m) => m.status === "hot" && usable(m)) ??
+                  modelsToSelect.find(usable));
+
+        // Reflect the choice in the composer either way.
+        setSelectedTool("J-Lens");
+        if (model) setSelectedModel(model.name);
+
+        // No J-Lens-supported model in the catalog — leave the tool selected so
+        // the composer shows it; nothing to launch.
+        if (!model) return;
+
+        // Empty chart (no prompt), mirroring the model launch dialog's deploy flow.
+        const params = new URLSearchParams({ model: model.name, tool: "J-Lens", deploy: "true" });
+        if (selectedWorkspace && selectedWorkspace !== "new") {
+            params.set("workspaceId", selectedWorkspace);
+        } else {
+            params.set("createNew", "true");
+        }
+
+        if (loggedIn && currentUser && !currentUser.is_anonymous) {
+            router.push(`/workbench?${params.toString()}`);
+        } else {
+            // Anonymous / signed-out — sign in via captcha, then resume here.
+            pendingLaunchRef.current = params.toString();
             setShowCaptcha(true);
         }
     };
@@ -511,10 +566,25 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
                         transition={{ duration: 0.6, delay: 0.2 }}
                         className="text-center space-y-4 mb-8 md:mb-16"
                     >
-                        {/* <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 border border-primary/20 text-sm text-primary">
-                            <Sparkles className="w-4 h-4" />
-                            <span>AI Interpretability Research Platform</span>
-                        </div> */}
+                        {/* J-Lens announcement — the tool's own icon + its name in
+                            the hero gradient. Clicking selects it in the composer. */}
+                        <button
+                            type="button"
+                            onClick={handleDiscoverJLens}
+                            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                        >
+                            <SparkBadge
+                                text="New"
+                                fontSize={46}
+                                className="h-6 w-9 shrink-0 -rotate-12"
+                            />
+                            <span>Discover our</span>
+                            <span className="bg-gradient-to-r from-primary to-purple-600 bg-clip-text font-semibold text-transparent">
+                                J-Lens
+                            </span>
+                            <JLensIcon className="h-4 w-4 text-purple-600 dark:text-purple-400" />
+                            <span>tool</span>
+                        </button>
 
                         <h1 className="text-5xl lg:text-7xl font-bold tracking-tight pt-2">
                             {/* <span className="bg-gradient-to-r from-foreground via-foreground to-foreground/80 bg-clip-text text-transparent">
@@ -696,6 +766,7 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
                                                 onClick={() => {
                                                     setShowCaptcha(false);
                                                     captchaRef.current?.resetCaptcha();
+                                                    pendingLaunchRef.current = null;
                                                 }}
                                                 variant="outline"
                                                 className="w-full"

--- a/workbench/_web/src/components/LandingPage.tsx
+++ b/workbench/_web/src/components/LandingPage.tsx
@@ -538,8 +538,8 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
 
                             <div className="relative p-6 space-y-4">
                                 <form onSubmit={handleSubmit} className="space-y-4">
-                                    {selectedTool === "Logit Lens" ? (
-                                        /* Logit Lens - Single prompt input */
+                                    {selectedTool !== "Activation Patching" ? (
+                                        /* Logit Lens / J-Lens - Single prompt input */
                                         <div className="relative">
                                             <Textarea
                                                 value={prompt}
@@ -647,12 +647,12 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
                                             disabled={
                                                 isSubmitting ||
                                                 !hasModels ||
-                                                (selectedTool === "Logit Lens"
-                                                    ? !prompt.trim()
-                                                    : !srcPrompt.trim() ||
+                                                (selectedTool === "Activation Patching"
+                                                    ? !srcPrompt.trim() ||
                                                       !tgtPrompt.trim() ||
                                                       srcPos.length === 0 ||
-                                                      srcPos.length !== tgtPos.length)
+                                                      srcPos.length !== tgtPos.length
+                                                    : !prompt.trim())
                                             }
                                         >
                                             <span>Run</span>

--- a/workbench/_web/src/components/LandingPage.tsx
+++ b/workbench/_web/src/components/LandingPage.tsx
@@ -27,7 +27,13 @@ import { cn } from "@/lib/utils";
 import PromptVisualization from "@/components/PromptVisualization";
 import type { Model, Token } from "@/types/models";
 import type { SourcePosition } from "@/types/activationPatching";
+import type { ToolType } from "@/types/charts";
 import { ActivationPatchingLandingInput } from "@/components/ActivationPatchingLandingInput";
+import {
+    isToolSupportedForModel,
+    unsupportedReasonFor,
+    toolTypeFromDisplay,
+} from "@/lib/toolSupport";
 
 type CurrentUser = SupabaseUser & { is_anonymous?: boolean | null };
 
@@ -42,6 +48,7 @@ function ModelPillOrSelect({
     onModelChange,
     disabled,
     loggedIn,
+    toolType,
 }: {
     modelsLoading: boolean;
     modelsError: boolean;
@@ -51,6 +58,9 @@ function ModelPillOrSelect({
     onModelChange: (value: string) => void;
     disabled: boolean;
     loggedIn: boolean;
+    /** The selected tool (if it restricts models); models it can't run are
+     * shown disabled with a reason. Null → no restriction. */
+    toolType: ToolType | null;
 }) {
     const triggerClass = PILL_TRIGGER;
 
@@ -108,6 +118,7 @@ function ModelPillOrSelect({
             onModelChange={onModelChange}
             disabled={disabled}
             loggedIn={loggedIn}
+            toolType={toolType}
         />
     );
 }
@@ -125,6 +136,7 @@ function ModelTriggerPopover({
     onModelChange,
     disabled,
     loggedIn,
+    toolType,
 }: {
     triggerClass: string;
     models: Model[];
@@ -133,6 +145,7 @@ function ModelTriggerPopover({
     onModelChange: (value: string) => void;
     disabled: boolean;
     loggedIn: boolean;
+    toolType: ToolType | null;
 }) {
     const [open, setOpen] = useState(false);
 
@@ -174,6 +187,10 @@ function ModelTriggerPopover({
                     }}
                     showSearch={false}
                     compact
+                    isModelDisabled={
+                        toolType ? (m) => !isToolSupportedForModel(toolType, m) : undefined
+                    }
+                    disabledReason={toolType ? (unsupportedReasonFor(toolType) ?? undefined) : undefined}
                     footer={
                         moreCount > 0 ? (
                             <Link
@@ -576,6 +593,7 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
                                                     onModelChange={setSelectedModel}
                                                     disabled={showCaptcha || isSubmitting}
                                                     loggedIn={loggedIn}
+                                                    toolType={toolTypeFromDisplay(selectedTool)}
                                                 />
                                             </div>
 
@@ -634,6 +652,7 @@ export function LandingPage({ loggedIn }: { loggedIn: boolean }) {
                                                     onModelChange={setSelectedModel}
                                                     disabled={showCaptcha || isSubmitting}
                                                     loggedIn={loggedIn}
+                                                    toolType={toolTypeFromDisplay(selectedTool)}
                                                 />
                                             </div>
                                         </div>

--- a/workbench/_web/src/components/LandingPage.tsx
+++ b/workbench/_web/src/components/LandingPage.tsx
@@ -190,7 +190,9 @@ function ModelTriggerPopover({
                     isModelDisabled={
                         toolType ? (m) => !isToolSupportedForModel(toolType, m) : undefined
                     }
-                    disabledReason={toolType ? (unsupportedReasonFor(toolType) ?? undefined) : undefined}
+                    disabledReason={
+                        toolType ? (unsupportedReasonFor(toolType) ?? undefined) : undefined
+                    }
                     footer={
                         moreCount > 0 ? (
                             <Link

--- a/workbench/_web/src/components/ModelControl.tsx
+++ b/workbench/_web/src/components/ModelControl.tsx
@@ -277,7 +277,9 @@ export function ModelControl({ className }: ModelControlProps) {
                     isModelDisabled={
                         activeTool ? (m) => !isToolSupportedForModel(activeTool, m) : undefined
                     }
-                    disabledReason={activeTool ? (unsupportedReasonFor(activeTool) ?? undefined) : undefined}
+                    disabledReason={
+                        activeTool ? (unsupportedReasonFor(activeTool) ?? undefined) : undefined
+                    }
                 />
             </PopoverContent>
         </Popover>

--- a/workbench/_web/src/components/ModelControl.tsx
+++ b/workbench/_web/src/components/ModelControl.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { useParams } from "next/navigation";
+import { usePathname, useParams } from "next/navigation";
 import { ChevronDown, Loader2 } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -11,8 +11,25 @@ import { useWorkspace } from "@/stores/useWorkspace";
 import { useModelsQuery } from "@/lib/api/modelsApi";
 import { useWorkspaceWorkshop } from "@/lib/api/workshopApi";
 import type { ModelStatus } from "@/types/models";
+import type { ToolType } from "@/types/charts";
 import { MODEL_STATUS, deriveHeat, splitRepo } from "@/components/model-selector/status";
 import { ModelPopover } from "@/components/model-selector/ModelPopover";
+import {
+    isToolModelRestricted,
+    isToolSupportedForModel,
+    unsupportedReasonFor,
+} from "@/lib/toolSupport";
+
+/** Workspace route segment (`/workbench/[id]/<segment>/[chartId]`) → the tool
+ * whose chart lives there. Used to gate the model picker to models the active
+ * tool supports. Segments not listed here (e.g. the legacy lens route, overview)
+ * impose no restriction. */
+const ROUTE_SEGMENT_TO_TOOL: Record<string, ToolType> = {
+    lens2: "lens2",
+    "j-lens": "jlens",
+    "activation-patching": "activation-patching",
+    "patch-lens": "patch-lens",
+};
 
 // ----- status vocabularies ----------------------------------------------------------
 
@@ -83,6 +100,16 @@ export function ModelControl({ className }: ModelControlProps) {
     const { data: workshop, isLoading: workshopLoading } = useWorkspaceWorkshop(workspaceId);
 
     const [open, setOpen] = React.useState(false);
+
+    // The tool of the chart currently open (from the route), so the picker can
+    // disable models it doesn't support. Null on non-tool routes / unrestricted
+    // tools → no gating.
+    const pathname = usePathname();
+    const activeTool = React.useMemo<ToolType | null>(() => {
+        const segment = pathname.split("/").filter(Boolean)[2];
+        const tool = segment ? ROUTE_SEGMENT_TO_TOOL[segment] : undefined;
+        return tool && isToolModelRestricted(tool) ? tool : null;
+    }, [pathname]);
 
     // Computed before the early returns so the useEffect below is called on
     // every render (Rules of Hooks).
@@ -247,6 +274,10 @@ export function ModelControl({ className }: ModelControlProps) {
                     selectedName={selectedModel.name}
                     onSelect={handleSelect}
                     selectableOnly
+                    isModelDisabled={
+                        activeTool ? (m) => !isToolSupportedForModel(activeTool, m) : undefined
+                    }
+                    disabledReason={activeTool ? (unsupportedReasonFor(activeTool) ?? undefined) : undefined}
                 />
             </PopoverContent>
         </Popover>

--- a/workbench/_web/src/components/SparkBadge.tsx
+++ b/workbench/_web/src/components/SparkBadge.tsx
@@ -1,10 +1,12 @@
 import * as React from "react";
 
 /**
- * Prototype "promo sticker" flagging a model that supports j-lens: an elongated
- * starburst seal (yellow fill, purple contour) reading "J Lens", meant to be
- * stuck on a corner of the model card. Deliberately loud — a spike to evaluate
- * the look. Elongated horizontally so the wordmark has room to breathe.
+ * A loud starburst "seal" badge — yellow fill, purple contour, centered text.
+ * The reusable spark/blast flag: the J-Lens model-card sticker and the landing
+ * "New" marker both use it. Sized by Tailwind `h-*`/`w-*` on `className` (the
+ * elongated 150×96 viewBox scales uniformly, so the spikes stay proportioned).
+ * `fontSize` is in viewBox units — bump it for short words so they fill the
+ * badge (e.g. "New") vs. a longer wordmark (e.g. "J Lens").
  */
 
 const CX = 75;
@@ -33,10 +35,22 @@ function burstPoints(
 // Wide, spiky star: deep inner/outer ratio → long points; rx > ry → elongated.
 const BURST = burstPoints(13, 72, 45, 52, 28);
 
-export function JLensStickerBadge({ className }: { className?: string }) {
+export function SparkBadge({
+    text,
+    label,
+    fontSize = 23,
+    className,
+}: {
+    text: string;
+    /** Accessible label / tooltip. Defaults to `text`. */
+    label?: string;
+    /** Text size in viewBox units (150×96). Larger for short words. */
+    fontSize?: number;
+    className?: string;
+}) {
     return (
-        <svg viewBox="0 0 150 96" role="img" aria-label="Supports J-Lens" className={className}>
-            <title>Supports J-Lens</title>
+        <svg viewBox="0 0 150 96" role="img" aria-label={label ?? text} className={className}>
+            <title>{label ?? text}</title>
             <polygon
                 points={BURST}
                 fill="#FDE047"
@@ -52,10 +66,10 @@ export function JLensStickerBadge({ className }: { className?: string }) {
                 dominantBaseline="middle"
                 fontFamily="var(--font-mono, ui-monospace, monospace)"
                 fontWeight={700}
-                fontSize={23}
+                fontSize={fontSize}
                 fill="#6D28D9"
             >
-                J Lens
+                {text}
             </text>
         </svg>
     );

--- a/workbench/_web/src/components/model-selector/ModelPopover.tsx
+++ b/workbench/_web/src/components/model-selector/ModelPopover.tsx
@@ -5,6 +5,7 @@ import { Check, Search } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { popoverMenuShellClass, popoverMenuShellStyle } from "@/components/ui/pill-popover";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
     MODEL_STATUS,
     deriveHeat,
@@ -47,6 +48,13 @@ interface ModelPopoverProps {
      * currently-selected model is always kept visible so the selection never
      * vanishes (e.g. a saved chart whose model has since gone cold). */
     selectableOnly?: boolean;
+    /** Marks models that can't be selected in the current context (e.g. a
+     * model the active tool doesn't support). Disabled rows stay visible but
+     * greyed out, are skipped by keyboard nav, and show `disabledReason` on
+     * hover so users understand why. */
+    isModelDisabled?: (model: Model) => boolean;
+    /** Tooltip text shown on a disabled row. */
+    disabledReason?: string;
 }
 
 export function ModelPopover({
@@ -57,7 +65,13 @@ export function ModelPopover({
     showSearch = true,
     compact = false,
     selectableOnly = false,
+    isModelDisabled,
+    disabledReason,
 }: ModelPopoverProps) {
+    const isDisabled = React.useCallback(
+        (m: Model) => (isModelDisabled ? isModelDisabled(m) : false),
+        [isModelDisabled],
+    );
     // Search query is owned internally; consumers that hide the search
     // (showSearch=false) don't need to thread dead state through.
     const [query, setQuery] = React.useState("");
@@ -81,6 +95,12 @@ export function ModelPopover({
         const compare = (a: Model, b: Model) => {
             if (a.name === selectedName) return -1;
             if (b.name === selectedName) return 1;
+            // Models the active tool doesn't support sink to the bottom of the
+            // group (below every selectable model), so the usable options stay
+            // at the top when a restricted tool (e.g. j-lens) is active.
+            const da = isDisabled(a) ? 1 : 0;
+            const db = isDisabled(b) ? 1 : 0;
+            if (da !== db) return da - db;
             return (
                 heatRank(a) - heatRank(b) ||
                 splitRepo(a.name).label.localeCompare(splitRepo(b.name).label)
@@ -89,7 +109,7 @@ export function ModelPopover({
         const base = models.filter((m) => !m.is_chat && matches(m)).sort(compare);
         const chat = models.filter((m) => m.is_chat && matches(m)).sort(compare);
         return { base, chat, flat: [...base, ...chat] };
-    }, [models, query, selectedName, selectableOnly]);
+    }, [models, query, selectedName, selectableOnly, isDisabled]);
 
     // Track the highlighted row by model NAME, not index. When the list
     // re-sorts (e.g. selecting a model pins it to the top), the index of the
@@ -122,7 +142,13 @@ export function ModelPopover({
 
     const moveActive = (delta: number) => {
         if (flat.length === 0) return;
-        const next = (active + delta + flat.length) % flat.length;
+        // Skip over disabled rows so keyboard nav lands only on selectable
+        // models. Bail after a full loop if every row is disabled.
+        let next = active;
+        for (let i = 0; i < flat.length; i++) {
+            next = (next + delta + flat.length) % flat.length;
+            if (!isDisabled(flat[next])) break;
+        }
         setActiveName(flat[next].name);
     };
 
@@ -136,7 +162,7 @@ export function ModelPopover({
         } else if (e.key === "Enter") {
             e.preventDefault();
             const target = flat[active];
-            if (target) onSelect(target.name);
+            if (target && !isDisabled(target)) onSelect(target.name);
         }
         // esc is handled by the host Popover.
     };
@@ -203,6 +229,8 @@ export function ModelPopover({
                                 onHover={setActiveName}
                                 rowRefs={rowRefs}
                                 compact={compact}
+                                isDisabled={isDisabled}
+                                disabledReason={disabledReason}
                             />
                         )}
                         {chat.length > 0 && (
@@ -216,6 +244,8 @@ export function ModelPopover({
                                 onHover={setActiveName}
                                 rowRefs={rowRefs}
                                 compact={compact}
+                                isDisabled={isDisabled}
+                                disabledReason={disabledReason}
                             />
                         )}
                     </>
@@ -241,6 +271,8 @@ function Group({
     onHover,
     rowRefs,
     compact,
+    isDisabled,
+    disabledReason,
 }: {
     title: string;
     count: number;
@@ -251,6 +283,8 @@ function Group({
     onHover: (name: string) => void;
     rowRefs: React.MutableRefObject<Map<string, HTMLButtonElement | null>>;
     compact: boolean;
+    isDisabled: (model: Model) => boolean;
+    disabledReason?: string;
 }) {
     // Visible row budget — keep the popover compact and signal overflow via
     // a soft bottom mask when there's more below the fold.
@@ -296,6 +330,8 @@ function Group({
                         model={m}
                         selected={m.name === selectedName}
                         active={m.name === activeName}
+                        disabled={isDisabled(m)}
+                        disabledReason={disabledReason}
                         onSelect={() => onSelect(m.name)}
                         onHover={() => onHover(m.name)}
                         compact={compact}
@@ -313,35 +349,41 @@ interface RowProps {
     model: Model;
     selected: boolean;
     active: boolean;
+    disabled?: boolean;
+    disabledReason?: string;
     onSelect: () => void;
     onHover: () => void;
     compact: boolean;
 }
 
 const Row = React.forwardRef<HTMLButtonElement, RowProps>(function Row(
-    { model, selected, active, onSelect, onHover, compact },
+    { model, selected, active, disabled = false, disabledReason, onSelect, onHover, compact },
     ref,
 ) {
     const { org, label } = splitRepo(model.name);
     const heat = deriveHeat(model);
     const meta = MODEL_STATUS[heat];
-    const muted = heat === "gated" || heat === "unavailable";
+    // A gated/unavailable model, or one the active tool doesn't support, reads
+    // as muted; a tool-unsupported model is additionally non-selectable.
+    const muted = heat === "gated" || heat === "unavailable" || disabled;
 
     const padX = compact ? "px-2" : "px-3";
     const selectedPadL = compact ? "pl-[6px]" : "pl-[10px]";
     const selectedPadR = compact ? "pr-2" : "pr-3";
 
-    return (
+    const button = (
         <button
             ref={ref}
             type="button"
             role="menuitem"
             aria-current={selected ? "true" : undefined}
-            onClick={onSelect}
+            aria-disabled={disabled || undefined}
+            onClick={disabled ? undefined : onSelect}
             onMouseEnter={onHover}
             onFocus={onHover}
             className={cn(
-                "w-full grid items-center text-left cursor-pointer outline-none",
+                "w-full grid items-center text-left outline-none",
+                disabled ? "cursor-not-allowed" : "cursor-pointer",
                 compact
                     ? "gap-2 py-1 grid-cols-[8px_1fr_auto]"
                     : "gap-2.5 py-1.5 grid-cols-[10px_1fr_auto]",
@@ -390,4 +432,19 @@ const Row = React.forwardRef<HTMLButtonElement, RowProps>(function Row(
             </span>
         </button>
     );
+
+    // A disabled row explains itself on hover (why the active tool can't use
+    // this model). `asChild` keeps the button as the trigger; `pointer-events`
+    // stays enabled on the button so the tooltip still fires despite the
+    // not-allowed cursor.
+    if (disabled && disabledReason) {
+        return (
+            <Tooltip>
+                <TooltipTrigger asChild>{button}</TooltipTrigger>
+                <TooltipContent side="right">{disabledReason}</TooltipContent>
+            </Tooltip>
+        );
+    }
+
+    return button;
 });

--- a/workbench/_web/src/components/models/JLensStickerBadge.tsx
+++ b/workbench/_web/src/components/models/JLensStickerBadge.tsx
@@ -35,12 +35,7 @@ const BURST = burstPoints(13, 72, 45, 52, 28);
 
 export function JLensStickerBadge({ className }: { className?: string }) {
     return (
-        <svg
-            viewBox="0 0 150 96"
-            role="img"
-            aria-label="Supports J-Lens"
-            className={className}
-        >
+        <svg viewBox="0 0 150 96" role="img" aria-label="Supports J-Lens" className={className}>
             <title>Supports J-Lens</title>
             <polygon
                 points={BURST}

--- a/workbench/_web/src/components/models/JLensStickerBadge.tsx
+++ b/workbench/_web/src/components/models/JLensStickerBadge.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+
+/**
+ * Prototype "promo sticker" flagging a model that supports j-lens: an elongated
+ * starburst seal (yellow fill, purple contour) reading "J Lens", meant to be
+ * stuck on a corner of the model card. Deliberately loud — a spike to evaluate
+ * the look. Elongated horizontally so the wordmark has room to breathe.
+ */
+
+const CX = 75;
+const CY = 48;
+
+// Build an elliptical starburst: `spikes` outer points alternating with inner
+// ones, on ellipses of radii (rx, ry). Elongating rx > ry stretches it wide.
+function burstPoints(
+    spikes: number,
+    outerRx: number,
+    outerRy: number,
+    innerRx: number,
+    innerRy: number,
+): string {
+    const pts: string[] = [];
+    const step = Math.PI / spikes;
+    for (let i = 0; i < spikes * 2; i++) {
+        const rx = i % 2 === 0 ? outerRx : innerRx;
+        const ry = i % 2 === 0 ? outerRy : innerRy;
+        const a = i * step - Math.PI / 2;
+        pts.push(`${(CX + rx * Math.cos(a)).toFixed(2)},${(CY + ry * Math.sin(a)).toFixed(2)}`);
+    }
+    return pts.join(" ");
+}
+
+// Wide, spiky star: deep inner/outer ratio → long points; rx > ry → elongated.
+const BURST = burstPoints(13, 72, 45, 52, 28);
+
+export function JLensStickerBadge({ className }: { className?: string }) {
+    return (
+        <svg
+            viewBox="0 0 150 96"
+            role="img"
+            aria-label="Supports J-Lens"
+            className={className}
+        >
+            <title>Supports J-Lens</title>
+            <polygon
+                points={BURST}
+                fill="#FDE047"
+                stroke="#7C3AED"
+                strokeWidth={4}
+                strokeLinejoin="miter"
+                strokeMiterlimit={10}
+            />
+            <text
+                x={CX}
+                y={CY + 1}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fontFamily="var(--font-mono, ui-monospace, monospace)"
+                fontWeight={700}
+                fontSize={23}
+                fill="#6D28D9"
+            >
+                J Lens
+            </text>
+        </svg>
+    );
+}

--- a/workbench/_web/src/components/models/ModelCard.tsx
+++ b/workbench/_web/src/components/models/ModelCard.tsx
@@ -85,29 +85,29 @@ export function ModelCard({ m, onClick, href }: ModelCardProps) {
             <div className="flex items-center justify-between gap-2">
                 {deploying ? (
                     <span
-                        className="inline-flex items-center gap-1.5 text-xs font-medium"
+                        className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium"
                         style={{ color: MODEL_STATUS.deploying.color }}
                     >
-                        <Loader2 className="w-3 h-3 animate-spin" />
-                        deploying
+                        <Loader2 className="w-3 h-3 shrink-0 animate-spin" />
+                        <span className="truncate">deploying</span>
                     </span>
                 ) : (
                     <span
-                        className="inline-flex items-center gap-1.5 text-xs font-medium"
+                        className="inline-flex min-w-0 items-center gap-1.5 text-xs font-medium"
                         style={{ color: heat.color }}
                     >
                         <span
-                            className="w-1.5 h-1.5 rounded-full"
+                            className="w-1.5 h-1.5 shrink-0 rounded-full"
                             style={{
                                 background: heat.color,
                                 boxShadow: `0 0 0 3px ${heat.color}26`,
                             }}
                         />
-                        {heat.label}
+                        <span className="truncate">{heat.label}</span>
                     </span>
                 )}
                 <span
-                    className="text-xs font-medium px-1.5 py-0.5 rounded border"
+                    className="shrink-0 whitespace-nowrap text-xs font-medium px-1.5 py-0.5 rounded border"
                     style={{
                         color: pillText,
                         background: pillBg,
@@ -194,7 +194,7 @@ export function ModelCard({ m, onClick, href }: ModelCardProps) {
                 {content}
             </div>
             {m.has_jacobian && (
-                <JLensStickerBadge className="pointer-events-none absolute right-2 top-10 z-10 h-9 w-14 rotate-12 drop-shadow-sm" />
+                <JLensStickerBadge className="pointer-events-none absolute right-2 top-10 z-10 h-7 w-11 rotate-12 drop-shadow-sm sm:h-9 sm:w-14" />
             )}
         </div>
     );

--- a/workbench/_web/src/components/models/ModelCard.tsx
+++ b/workbench/_web/src/components/models/ModelCard.tsx
@@ -11,7 +11,7 @@ import {
     type ModelHeat,
     type ModelGroup,
 } from "@/components/model-selector/status";
-import { JLensStickerBadge } from "./JLensStickerBadge";
+import { SparkBadge } from "@/components/SparkBadge";
 
 export interface ModelCardModel {
     org: string;
@@ -194,7 +194,11 @@ export function ModelCard({ m, onClick, href }: ModelCardProps) {
                 {content}
             </div>
             {m.has_jacobian && (
-                <JLensStickerBadge className="pointer-events-none absolute right-2 top-10 z-10 h-7 w-11 rotate-12 drop-shadow-sm sm:h-9 sm:w-14" />
+                <SparkBadge
+                    text="J-Lens"
+                    label="Supports J-Lens"
+                    className="pointer-events-none absolute right-2 top-10 z-10 h-7 w-11 rotate-12 drop-shadow-sm sm:h-9 sm:w-14"
+                />
             )}
         </div>
     );

--- a/workbench/_web/src/components/models/ModelCard.tsx
+++ b/workbench/_web/src/components/models/ModelCard.tsx
@@ -11,6 +11,7 @@ import {
     type ModelHeat,
     type ModelGroup,
 } from "@/components/model-selector/status";
+import { JLensStickerBadge } from "./JLensStickerBadge";
 
 export interface ModelCardModel {
     org: string;
@@ -22,6 +23,9 @@ export interface ModelCardModel {
     /** True while a deployment warmup is in flight for this model — the card
      * shows a spinner + "deploying" instead of the heat dot / Deploy action. */
     deploying?: boolean;
+    /** Whether the model has a Jacobian lens (i.e. supports j-lens). Used only
+     * to order the display — cold models without one sort to the bottom. */
+    has_jacobian?: boolean;
 }
 
 interface ModelCardProps {
@@ -183,8 +187,15 @@ export function ModelCard({ m, onClick, href }: ModelCardProps) {
         : {};
 
     return (
-        <div className={shell} style={style} aria-label={ariaLabel} {...interactive}>
-            {content}
+        // Relative wrapper (no clipping) so the j-lens sticker can overhang the
+        // card's rounded, overflow-hidden shell.
+        <div className="relative w-full min-w-0">
+            <div className={shell} style={style} aria-label={ariaLabel} {...interactive}>
+                {content}
+            </div>
+            {m.has_jacobian && (
+                <JLensStickerBadge className="pointer-events-none absolute right-2 top-10 z-10 h-9 w-14 rotate-12 drop-shadow-sm" />
+            )}
         </div>
     );
 }

--- a/workbench/_web/src/components/models/ModelLaunchDialog.tsx
+++ b/workbench/_web/src/components/models/ModelLaunchDialog.tsx
@@ -190,9 +190,7 @@ export function ModelLaunchDialog({ model, mode, onOpenChange }: ModelLaunchDial
                         {!toolSupported && unsupportedReason && (
                             <div className="flex items-start gap-2 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700/40 dark:bg-amber-950/30 dark:text-amber-200">
                                 <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-                                <span>
-                                    {unsupportedReason} Pick a different tool or model.
-                                </span>
+                                <span>{unsupportedReason} Pick a different tool or model.</span>
                             </div>
                         )}
                     </div>

--- a/workbench/_web/src/components/models/ModelLaunchDialog.tsx
+++ b/workbench/_web/src/components/models/ModelLaunchDialog.tsx
@@ -19,11 +19,17 @@ import { createClient } from "@/lib/supabase/client";
 import { getWorkspaces } from "@/lib/queries/workspaceQueries";
 import { hasWorkshopClaim } from "@/lib/workshop";
 import { useModelDeployment } from "@/stores/useModelDeployment";
+import { useModelsQuery } from "@/lib/api/modelsApi";
 import {
     ToolPill,
     WorkspacePill,
     NEUTRAL_PILL_TRIGGER,
 } from "@/components/selectors/LaunchSelectors";
+import {
+    isToolSupportedForModel,
+    unsupportedReasonFor,
+    toolTypeFromDisplay,
+} from "@/lib/toolSupport";
 import type { ModelCardModel } from "./ModelCard";
 
 const AUTH_DISABLED = process.env.NEXT_PUBLIC_DISABLE_AUTH === "true";
@@ -58,6 +64,18 @@ export function ModelLaunchDialog({ model, mode, onOpenChange }: ModelLaunchDial
 
     const open = model !== null;
     const isDeploy = mode === "deploy";
+
+    // The dialog's model is fixed (the card that opened it); gate the tool
+    // choice against it. ModelCardModel doesn't carry capability flags, so look
+    // the full model up in the catalog to read `has_jacobian` etc.
+    const { data: catalogModels } = useModelsQuery();
+    const fullModelName = model ? (model.org ? `${model.org}/${model.name}` : model.name) : null;
+    const modelObj = catalogModels?.find((m) => m.name === fullModelName);
+    const toolType = toolTypeFromDisplay(tool);
+    // Fail open while the catalog is still loading (modelObj undefined) so we
+    // don't block a valid launch on a slow fetch; the chart itself still guards.
+    const toolSupported = !toolType || !modelObj || isToolSupportedForModel(toolType, modelObj);
+    const unsupportedReason = toolType ? unsupportedReasonFor(toolType) : null;
 
     useEffect(() => {
         if (!open) return;
@@ -169,6 +187,14 @@ export function ModelLaunchDialog({ model, mode, onOpenChange }: ModelLaunchDial
                                 modal
                             />
                         </div>
+                        {!toolSupported && unsupportedReason && (
+                            <div className="flex items-start gap-2 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-700/40 dark:bg-amber-950/30 dark:text-amber-200">
+                                <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                                <span>
+                                    {unsupportedReason} Pick a different tool or model.
+                                </span>
+                            </div>
+                        )}
                     </div>
                 ) : (
                     <p className="text-sm text-muted-foreground py-1">
@@ -180,7 +206,7 @@ export function ModelLaunchDialog({ model, mode, onOpenChange }: ModelLaunchDial
 
                 <DialogFooter>
                     {isSignedIn ? (
-                        <Button type="button" onClick={handleSubmit}>
+                        <Button type="button" onClick={handleSubmit} disabled={!toolSupported}>
                             {isDeploy && <Cloud className="h-4 w-4" />}
                             {isDeploy ? "Deploy + New Chart" : "New"}
                         </Button>

--- a/workbench/_web/src/components/models/ModelRowCarousel.tsx
+++ b/workbench/_web/src/components/models/ModelRowCarousel.tsx
@@ -4,12 +4,16 @@ import { useCallback, useEffect, useRef, useState, type Ref } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { ModelCard, type ModelCardModel } from "./ModelCard";
 
-// Max columns visible at once (the widest breakpoint). Kept in sync with the
-// `lg:[--cols:4]` grid class below — the row-count heuristic assumes this many
-// columns. Change both together.
+// Visible columns at the widest vs. the mobile breakpoint. Kept in sync with the
+// `[--cols:2] md:[--cols:3] lg:[--cols:4]` grid classes below — the row-count
+// heuristic uses the actual visible column count so small lists don't force
+// horizontal scrolling (fewer visible columns → pack into more rows). Change
+// these together with the grid classes.
 const MAX_VISIBLE_COLS = 4;
+const MOBILE_VISIBLE_COLS = 2;
 
 /**
  * Scroll state + paging for the model carousel, lifted out of the grid so the
@@ -131,10 +135,10 @@ interface ModelRowCarouselProps {
 
 /**
  * Horizontal scroller with a column-major grid (cards stack vertically down
- * `rows` then progress horizontally). The viewport is sized so exactly 4 columns
- * are visible at `lg+` breakpoints (3 at md, 2 at sm, 1 below); anything past
- * that is reachable by scrolling. The nav controls (progress + arrows) live in
- * the section header via `CarouselControls`; this renders the grid + edge fades.
+ * `rows` then progress horizontally). The viewport is sized so 4 columns are
+ * visible at `lg+` (3 at md, 2 below md); anything past that is reachable by
+ * scrolling. The nav controls (progress + arrows) live in the section header
+ * via `CarouselControls`; this renders the grid + edge fades.
  */
 export function ModelRowCarousel({
     models,
@@ -145,6 +149,12 @@ export function ModelRowCarousel({
     onCardClick,
     cardHref,
 }: ModelRowCarouselProps) {
+    // Row count depends on how many columns are actually visible: with fewer
+    // visible columns (mobile) a small list should pack into more rows so it
+    // fits without horizontal scrolling. `undefined` (pre-hydration) → desktop.
+    const visibleCols = useIsMobile() === true ? MOBILE_VISIBLE_COLS : MAX_VISIBLE_COLS;
+    const rowCount = Math.min(rows, Math.max(1, Math.ceil(models.length / visibleCols)));
+
     return (
         <div className="relative">
             <div
@@ -152,17 +162,18 @@ export function ModelRowCarousel({
                 className={cn(
                     "grid gap-3 overflow-x-auto py-0.5",
                     "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
-                    // Card column width: container split into 1 / 2 / 3 / 4
-                    // visible columns by breakpoint (see MAX_VISIBLE_COLS). The
-                    // math accounts for (N-1) gaps inside the visible viewport.
-                    "[--cols:1] sm:[--cols:2] md:[--cols:3] lg:[--cols:4]",
+                    // Card column width: container split into 2 / 3 / 4 visible
+                    // columns by breakpoint (see MAX_VISIBLE_COLS). The math
+                    // accounts for (N-1) gaps inside the visible viewport. Cards
+                    // shrink to fit two columns even on the narrowest phones.
+                    "[--cols:2] md:[--cols:3] lg:[--cols:4]",
                 )}
                 style={{
                     gridAutoFlow: "column",
-                    // Stack into as many rows as the cards need (assuming the
-                    // widest breakpoint's column count), capped at `rows`. Few
+                    // Stack into as many rows as the cards need for the current
+                    // breakpoint's visible column count, capped at `rows`. Few
                     // cards stay a single line instead of leaving empty rows.
-                    gridTemplateRows: `repeat(${Math.min(rows, Math.max(1, Math.ceil(models.length / MAX_VISIBLE_COLS)))}, auto)`,
+                    gridTemplateRows: `repeat(${rowCount}, auto)`,
                     // Cap each card at 268px so cards don't stretch hollow on
                     // wide viewports, while still shrinking below the cap at
                     // small viewports.
@@ -205,7 +216,9 @@ export function ModelRowCarousel({
 function ScrollProgress({ progress }: { progress: number }) {
     const filled = Math.min(100, 24 + progress * 76);
     return (
-        <div className="relative w-[140px] h-1 rounded-full bg-muted overflow-hidden">
+        // Responsive width: compact on phones so [filters button][progress]
+        // [prev/next] fit the header on one row; full-size on desktop.
+        <div className="relative h-1 w-16 sm:w-24 lg:w-[140px] rounded-full bg-muted overflow-hidden">
             <div
                 className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-primary to-purple-600"
                 style={{ width: `${filled}%` }}

--- a/workbench/_web/src/components/models/ModelRowCarousel.tsx
+++ b/workbench/_web/src/components/models/ModelRowCarousel.tsx
@@ -1,152 +1,203 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type Ref } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ModelCard, type ModelCardModel } from "./ModelCard";
 
+// Max columns visible at once (the widest breakpoint). Kept in sync with the
+// `lg:[--cols:4]` grid class below — the row-count heuristic assumes this many
+// columns. Change both together.
+const MAX_VISIBLE_COLS = 4;
+
+/**
+ * Scroll state + paging for the model carousel, lifted out of the grid so the
+ * nav controls can render elsewhere (the section header). Pass a value that
+ * changes when the content does (e.g. the model list) to re-measure on change.
+ *
+ * `scrollRef` is a **callback ref** (not a ref object) so the scroll/resize
+ * listeners re-attach every time the grid element mounts — the carousel is
+ * conditionally rendered (hidden while the section is collapsed), so on reopen
+ * a fresh element mounts and must be re-measured, or the controls stay hidden.
+ */
+export function useCarouselScroll(deps?: unknown) {
+    const elRef = useRef<HTMLDivElement | null>(null);
+    const cleanupRef = useRef<(() => void) | null>(null);
+    const pageWidthRef = useRef(0);
+    const [progress, setProgress] = useState(0);
+    const [hasOverflow, setHasOverflow] = useState(false);
+
+    const measure = useCallback(() => {
+        const el = elRef.current;
+        if (!el) return;
+        const max = el.scrollWidth - el.clientWidth;
+        setHasOverflow(max > 1);
+        setProgress(max > 0 ? el.scrollLeft / max : 0);
+        pageWidthRef.current = el.clientWidth;
+    }, []);
+
+    const scrollRef = useCallback(
+        (el: HTMLDivElement | null) => {
+            // Tear down the previous element's listeners before (re)binding.
+            cleanupRef.current?.();
+            cleanupRef.current = null;
+            elRef.current = el;
+            if (!el) {
+                // Detached (e.g. the section collapsed, or the list filtered to
+                // zero and the carousel was swapped out) — clear the state so
+                // the header's nav controls hide instead of lingering.
+                setHasOverflow(false);
+                setProgress(0);
+                return;
+            }
+            measure();
+            el.addEventListener("scroll", measure, { passive: true });
+            const ro = new ResizeObserver(measure);
+            ro.observe(el);
+            cleanupRef.current = () => {
+                el.removeEventListener("scroll", measure);
+                ro.disconnect();
+            };
+        },
+        [measure],
+    );
+
+    // Content growth changes scrollWidth without resizing the container, so the
+    // ResizeObserver alone misses it — re-measure when the list changes.
+    useEffect(() => {
+        measure();
+    }, [deps, measure]);
+
+    // Page by the visible width — one click moves by ~one full screen of cards.
+    const scrollByPage = (dir: -1 | 1) =>
+        elRef.current?.scrollBy({ left: dir * pageWidthRef.current, behavior: "smooth" });
+
+    return { scrollRef, progress, hasOverflow, scrollByPage };
+}
+
+/** Progress bar + left/right paging buttons. Rendered in the section header. */
+export function CarouselControls({
+    progress,
+    scrollByPage,
+    label = "models",
+}: {
+    progress: number;
+    scrollByPage: (dir: -1 | 1) => void;
+    label?: string;
+}) {
+    return (
+        <div className="flex items-center gap-2">
+            <ScrollProgress progress={progress} />
+            <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => scrollByPage(-1)}
+                disabled={progress <= 0.001}
+                aria-label={`Scroll ${label} left`}
+            >
+                <ChevronLeft className="w-3 h-3" />
+            </Button>
+            <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-6 w-6"
+                onClick={() => scrollByPage(1)}
+                disabled={progress >= 0.999}
+                aria-label={`Scroll ${label} right`}
+            >
+                <ChevronRight className="w-3 h-3" />
+            </Button>
+        </div>
+    );
+}
+
 interface ModelRowCarouselProps {
-    label: string;
     models: ModelCardModel[];
+    /** Max stacked rows in the column-major grid (once there are enough cards
+     * to fill a second/third row). Defaults to 2. */
+    rows?: number;
+    /** Scroll state from `useCarouselScroll` (owned by the parent so the nav
+     * controls can live in the section header). `scrollRef` is a callback ref. */
+    scrollRef: Ref<HTMLDivElement>;
+    progress: number;
+    hasOverflow: boolean;
     onCardClick?: (m: ModelCardModel) => void;
     cardHref?: (m: ModelCardModel) => string | undefined;
 }
 
 /**
- * Two-row horizontal scroller, column-major flow (card pairs stack vertically
- * then progress horizontally). The viewport is sized so exactly 4 columns are
- * visible at `lg+` breakpoints (3 at md, 2 at sm, 1 below); anything past that
- * is reachable by scrolling. Nav buttons + progress + edge fades appear only
- * when there's something to scroll to.
+ * Horizontal scroller with a column-major grid (cards stack vertically down
+ * `rows` then progress horizontally). The viewport is sized so exactly 4 columns
+ * are visible at `lg+` breakpoints (3 at md, 2 at sm, 1 below); anything past
+ * that is reachable by scrolling. The nav controls (progress + arrows) live in
+ * the section header via `CarouselControls`; this renders the grid + edge fades.
  */
-export function ModelRowCarousel({ label, models, onCardClick, cardHref }: ModelRowCarouselProps) {
-    const ref = useRef<HTMLDivElement>(null);
-    const [progress, setProgress] = useState(0);
-    const [hasOverflow, setHasOverflow] = useState(false);
-    const [pageWidth, setPageWidth] = useState(0);
-
-    useEffect(() => {
-        const el = ref.current;
-        if (!el) return;
-        const update = () => {
-            const max = el.scrollWidth - el.clientWidth;
-            setHasOverflow(max > 1);
-            setProgress(max > 0 ? el.scrollLeft / max : 0);
-            setPageWidth(el.clientWidth);
-        };
-        update();
-        el.addEventListener("scroll", update, { passive: true });
-        const ro = new ResizeObserver(update);
-        ro.observe(el);
-        return () => {
-            el.removeEventListener("scroll", update);
-            ro.disconnect();
-        };
-    }, [models]);
-
-    // Page by the visible width — one click moves by ~one full screen of cards.
-    const scrollByPage = (dir: -1 | 1) =>
-        ref.current?.scrollBy({ left: dir * pageWidth, behavior: "smooth" });
-
+export function ModelRowCarousel({
+    models,
+    rows = 2,
+    scrollRef,
+    progress,
+    hasOverflow,
+    onCardClick,
+    cardHref,
+}: ModelRowCarouselProps) {
     return (
         <div className="relative">
-            <div className="flex items-baseline justify-between gap-3 px-1 pt-3.5 pb-2">
-                <div className="flex items-baseline gap-2">
-                    <span className="text-sm font-medium text-foreground">{label}</span>
-                    <span className="text-xs text-muted-foreground tabular-nums">
-                        {models.length}
-                    </span>
-                </div>
-
-                {hasOverflow && (
-                    <div className="flex items-center gap-2">
-                        <ScrollProgress progress={progress} />
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="icon"
-                            className="h-6 w-6"
-                            onClick={() => scrollByPage(-1)}
-                            disabled={progress <= 0.001}
-                            aria-label={`Scroll ${label} left`}
-                        >
-                            <ChevronLeft className="w-3 h-3" />
-                        </Button>
-                        <Button
-                            type="button"
-                            variant="outline"
-                            size="icon"
-                            className="h-6 w-6"
-                            onClick={() => scrollByPage(1)}
-                            disabled={progress >= 0.999}
-                            aria-label={`Scroll ${label} right`}
-                        >
-                            <ChevronRight className="w-3 h-3" />
-                        </Button>
-                    </div>
+            <div
+                ref={scrollRef}
+                className={cn(
+                    "grid gap-3 overflow-x-auto py-0.5",
+                    "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+                    // Card column width: container split into 1 / 2 / 3 / 4
+                    // visible columns by breakpoint (see MAX_VISIBLE_COLS). The
+                    // math accounts for (N-1) gaps inside the visible viewport.
+                    "[--cols:1] sm:[--cols:2] md:[--cols:3] lg:[--cols:4]",
                 )}
+                style={{
+                    gridAutoFlow: "column",
+                    // Stack into as many rows as the cards need (assuming the
+                    // widest breakpoint's column count), capped at `rows`. Few
+                    // cards stay a single line instead of leaving empty rows.
+                    gridTemplateRows: `repeat(${Math.min(rows, Math.max(1, Math.ceil(models.length / MAX_VISIBLE_COLS)))}, auto)`,
+                    // Cap each card at 268px so cards don't stretch hollow on
+                    // wide viewports, while still shrinking below the cap at
+                    // small viewports.
+                    gridAutoColumns:
+                        "min(268px, calc((100% - (var(--cols) - 1) * 12px) / var(--cols)))",
+                }}
+            >
+                {/* The caller (ModelsSection) renders its own empty state and
+                    only mounts this with a non-empty list. */}
+                {models.map((m) => (
+                    <ModelCard
+                        key={`${m.org}/${m.name}`}
+                        m={m}
+                        onClick={onCardClick ? () => onCardClick(m) : undefined}
+                        href={cardHref?.(m)}
+                    />
+                ))}
             </div>
 
-            <div className="relative">
+            {progress > 0.01 && (
                 <div
-                    ref={ref}
                     className={cn(
-                        "grid gap-3 overflow-x-auto py-0.5",
-                        "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
-                        // Card column width: container split into 1 / 2 / 3 / 4
-                        // visible columns by breakpoint. The math accounts for
-                        // (N-1) gaps inside the visible viewport.
-                        "[--cols:1] sm:[--cols:2] md:[--cols:3] lg:[--cols:4]",
+                        "pointer-events-none absolute inset-y-0 left-0 w-6",
+                        "bg-gradient-to-r from-background to-transparent",
                     )}
-                    style={{
-                        gridAutoFlow: "column",
-                        // Only stack into a second row when the group has more
-                        // than 4 models — otherwise the row stays a single line.
-                        gridTemplateRows: models.length > 4 ? "repeat(2, auto)" : "auto",
-                        // Cap each card at 268px so cards don't stretch
-                        // hollow on wide viewports, while still shrinking
-                        // below the cap at small viewports.
-                        gridAutoColumns:
-                            "min(268px, calc((100% - (var(--cols) - 1) * 12px) / var(--cols)))",
-                    }}
-                >
-                    {models.length === 0 ? (
-                        <div
-                            className="px-3.5 py-6 rounded-md border border-dashed bg-muted/30 text-center text-xs text-muted-foreground"
-                            style={{ gridColumn: "1 / -1", gridRow: "1 / -1" }}
-                        >
-                            no models match the current filters
-                        </div>
-                    ) : (
-                        models.map((m) => (
-                            <ModelCard
-                                key={`${m.org}/${m.name}`}
-                                m={m}
-                                onClick={onCardClick ? () => onCardClick(m) : undefined}
-                                href={cardHref?.(m)}
-                            />
-                        ))
+                />
+            )}
+            {hasOverflow && progress < 0.99 && (
+                <div
+                    className={cn(
+                        "pointer-events-none absolute inset-y-0 right-0 w-6",
+                        "bg-gradient-to-l from-background to-transparent",
                     )}
-                </div>
-
-                {progress > 0.01 && (
-                    <div
-                        className={cn(
-                            "pointer-events-none absolute inset-y-0 left-0 w-6",
-                            "bg-gradient-to-r from-background to-transparent",
-                        )}
-                    />
-                )}
-                {hasOverflow && progress < 0.99 && (
-                    <div
-                        className={cn(
-                            "pointer-events-none absolute inset-y-0 right-0 w-6",
-                            "bg-gradient-to-l from-background to-transparent",
-                        )}
-                    />
-                )}
-            </div>
+                />
+            )}
         </div>
     );
 }

--- a/workbench/_web/src/components/models/ModelRowCarousel.tsx
+++ b/workbench/_web/src/components/models/ModelRowCarousel.tsx
@@ -216,9 +216,9 @@ export function ModelRowCarousel({
 function ScrollProgress({ progress }: { progress: number }) {
     const filled = Math.min(100, 24 + progress * 76);
     return (
-        // Responsive width: compact on phones so [filters button][progress]
-        // [prev/next] fit the header on one row; full-size on desktop.
-        <div className="relative h-1 w-16 sm:w-24 lg:w-[140px] rounded-full bg-muted overflow-hidden">
+        // Slightly narrower on md, full-size on lg+. (Controls are hidden on
+        // mobile, where the carousel is scrolled by touch.)
+        <div className="relative h-1 w-24 lg:w-[140px] rounded-full bg-muted overflow-hidden">
             <div
                 className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-primary to-purple-600"
                 style={{ width: `${filled}%` }}

--- a/workbench/_web/src/components/models/ModelsSection.tsx
+++ b/workbench/_web/src/components/models/ModelsSection.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/components/model-selector/status";
 import { useModelsSection } from "@/stores/useModelsSection";
 import { useModelDeployment } from "@/stores/useModelDeployment";
-import { ModelRowCarousel } from "./ModelRowCarousel";
+import { ModelRowCarousel, useCarouselScroll, CarouselControls } from "./ModelRowCarousel";
 import { ModelsSectionHeader } from "./ModelsSectionHeader";
 import { ModelsFetchErrorBanner } from "./ModelsFetchErrorBanner";
 import { ModelLaunchDialog, type ModelLaunchMode } from "./ModelLaunchDialog";
@@ -224,8 +224,10 @@ export function ModelsSection({
             .sort(byHeat);
     }, [cards, query, statusFilters, groupFilters]);
 
-    const baseCards = useMemo(() => filtered.filter((m) => m.group === "base"), [filtered]);
-    const chatCards = useMemo(() => filtered.filter((m) => m.group === "chat"), [filtered]);
+    // Carousel scroll state lives here so its nav controls can render up in the
+    // section header (next to the filters) rather than above the row. Re-measure
+    // whenever the visible list changes.
+    const { scrollRef, progress, hasOverflow, scrollByPage } = useCarouselScroll(filtered);
 
     const groupPreviews = useMemo(() => {
         const previewFor = (list: ModelCardModel[]) => {
@@ -316,9 +318,13 @@ export function ModelsSection({
                     onToggleStatus={onToggleStatus}
                     groupFilters={groupFilters}
                     onToggleGroup={onToggleGroup}
+                    scrollControls={
+                        hasOverflow ? (
+                            <CarouselControls progress={progress} scrollByPage={scrollByPage} />
+                        ) : null
+                    }
                 />
             </div>
-            {!collapsed && <div aria-hidden className="mx-6 h-px bg-border" />}
 
             {!collapsed && (
                 <div className="p-3 pt-1">
@@ -332,64 +338,30 @@ export function ModelsSection({
                         <div className="py-8 text-center text-xs text-muted-foreground">
                             No models available
                         </div>
+                    ) : filtered.length === 0 ? (
+                        <div className="py-8 text-center text-xs text-muted-foreground">
+                            No models match the current filters.
+                        </div>
                     ) : (
-                        (() => {
-                            // A row is shown only if its group is not filtered
-                            // out AND it has at least one card after the
-                            // active filters (search + status + group). When
-                            // both rows end up empty due to filters, swap in
-                            // a single "no matches" message instead of two
-                            // empty placeholders.
-                            const showBase =
-                                (groupFilters.size === 0 || groupFilters.has("base")) &&
-                                baseCards.length > 0;
-                            const showChat =
-                                (groupFilters.size === 0 || groupFilters.has("chat")) &&
-                                chatCards.length > 0;
-                            if (!showBase && !showChat) {
-                                return (
-                                    <div className="py-8 text-center text-xs text-muted-foreground">
-                                        No models match the current filters.
-                                    </div>
-                                );
+                        // Base and chat share one scroller now — the card's
+                        // group pill already signals the family, so a hard
+                        // section split isn't needed. Three rows deep.
+                        <ModelRowCarousel
+                            models={filtered}
+                            rows={3}
+                            scrollRef={scrollRef}
+                            progress={progress}
+                            hasOverflow={hasOverflow}
+                            cardHref={cardHref}
+                            onCardClick={
+                                onCardClick ??
+                                ((m) =>
+                                    setDialog({
+                                        model: m,
+                                        mode: m.heat === "cold" ? "deploy" : "launch",
+                                    }))
                             }
-                            return (
-                                <>
-                                    {showBase && (
-                                        <ModelRowCarousel
-                                            label="Base"
-                                            models={baseCards}
-                                            cardHref={cardHref}
-                                            onCardClick={
-                                                onCardClick ??
-                                                ((m) =>
-                                                    setDialog({
-                                                        model: m,
-                                                        mode:
-                                                            m.heat === "cold" ? "deploy" : "launch",
-                                                    }))
-                                            }
-                                        />
-                                    )}
-                                    {showChat && (
-                                        <ModelRowCarousel
-                                            label="Chat"
-                                            models={chatCards}
-                                            cardHref={cardHref}
-                                            onCardClick={
-                                                onCardClick ??
-                                                ((m) =>
-                                                    setDialog({
-                                                        model: m,
-                                                        mode:
-                                                            m.heat === "cold" ? "deploy" : "launch",
-                                                    }))
-                                            }
-                                        />
-                                    )}
-                                </>
-                            );
-                        })()
+                        />
                     )}
                 </div>
             )}

--- a/workbench/_web/src/components/models/ModelsSection.tsx
+++ b/workbench/_web/src/components/models/ModelsSection.tsx
@@ -39,7 +39,18 @@ const byHeat = (a: ModelCardModel, b: ModelCardModel) => {
     const aDeploying = !!a.deploying || a.heat === "deploying";
     const bDeploying = !!b.deploying || b.heat === "deploying";
     if (aDeploying !== bDeploying) return aDeploying ? -1 : 1;
-    return heatRank(a.heat) - heatRank(b.heat) || a.name.localeCompare(b.name);
+
+    const heatDiff = heatRank(a.heat) - heatRank(b.heat);
+    if (heatDiff !== 0) return heatDiff;
+
+    // Within the cold tier, push models without a Jacobian lens to the bottom
+    // so the j-lens-capable cold models a user would deploy surface first.
+    if (a.heat === "cold" && b.heat === "cold") {
+        const jacobianDiff = Number(!!b.has_jacobian) - Number(!!a.has_jacobian);
+        if (jacobianDiff !== 0) return jacobianDiff;
+    }
+
+    return a.name.localeCompare(b.name);
 };
 
 /** Content-equality for Sets. Used by the URL→state sync effects so they
@@ -68,6 +79,7 @@ const toCardModel = (m: Model, isSignedIn: boolean): ModelCardModel => {
         heat,
         params: m.params,
         layers: m.n_layers,
+        has_jacobian: m.has_jacobian,
     };
 };
 

--- a/workbench/_web/src/components/models/ModelsSectionHeader.tsx
+++ b/workbench/_web/src/components/models/ModelsSectionHeader.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
-import { AlertTriangle, ChevronDown, Loader2, Search, X } from "lucide-react";
+import { useEffect, useRef, type RefObject } from "react";
+import { AlertTriangle, ChevronDown, Loader2, Search, SlidersHorizontal, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { useIsDark } from "@/hooks/useIsDark";
 import {
@@ -63,6 +64,7 @@ export function ModelsSectionHeader({
 }: ModelsSectionHeaderProps) {
     const searchRef = useRef<HTMLInputElement>(null);
     const filtered = filteredTotal !== total;
+    const activeFilterCount = groupFilters.size + statusFilters.size + (query.trim() ? 1 : 0);
 
     useEffect(() => {
         const onKey = (e: KeyboardEvent) => {
@@ -133,61 +135,63 @@ export function ModelsSectionHeader({
                 )}
 
                 {!collapsed && (
-                    <div className="flex flex-wrap items-center gap-3">
-                        <div className="relative">
-                            <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
-                            <Input
-                                ref={searchRef}
-                                value={query}
-                                onChange={(e) => onQuery(e.target.value)}
-                                placeholder="search models…"
-                                aria-label="Search models"
-                                className="h-7 w-44 pl-7 pr-7 text-xs"
+                    <>
+                        {/* Desktop: filters inline. */}
+                        <div className="hidden gap-3 md:flex md:flex-wrap md:items-center">
+                            <FilterControls
+                                searchRef={searchRef}
+                                query={query}
+                                onQuery={onQuery}
+                                groupFilters={groupFilters}
+                                onToggleGroup={onToggleGroup}
+                                statusFilters={statusFilters}
+                                onToggleStatus={onToggleStatus}
                             />
-                            {query && (
-                                <button
+                        </div>
+
+                        {/* Mobile: collapse filters behind a button + popover so
+                            they don't consume rows of vertical space. */}
+                        <Popover>
+                            <PopoverTrigger asChild>
+                                <Button
                                     type="button"
-                                    onClick={() => onQuery("")}
-                                    aria-label="Clear search"
-                                    className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                                    variant="outline"
+                                    size="icon"
+                                    className={cn(
+                                        "relative h-7 w-7 md:hidden",
+                                        activeFilterCount > 0 && "border-primary/40 text-primary",
+                                    )}
+                                    aria-label={
+                                        activeFilterCount > 0
+                                            ? `Filters (${activeFilterCount} active)`
+                                            : "Filters"
+                                    }
                                 >
-                                    <X className="h-3 w-3" />
-                                </button>
-                            )}
-                        </div>
-
-                        <div className="flex items-center gap-1.5">
-                            <span className="text-xs text-muted-foreground">type</span>
-                            <SegmentedGroup label="Filter by model type">
-                                {GROUPS.map((g) => (
-                                    <FilterChip
-                                        key={g}
-                                        label={g}
-                                        color={GROUP_COLOR[g]}
-                                        active={groupFilters.has(g)}
-                                        onClick={() => onToggleGroup(g)}
-                                    />
-                                ))}
-                            </SegmentedGroup>
-                        </div>
-
-                        <div className="flex items-center gap-1.5">
-                            <span className="text-xs text-muted-foreground">status</span>
-                            <SegmentedGroup label="Filter by status">
-                                {FILTERABLE_HEAT.map((k) => (
-                                    <FilterChip
-                                        key={k}
-                                        label={k}
-                                        color={MODEL_STATUS[k].color}
-                                        active={statusFilters.has(k)}
-                                        onClick={() => onToggleStatus(k)}
-                                    />
-                                ))}
-                            </SegmentedGroup>
-                        </div>
+                                    <SlidersHorizontal className="h-3.5 w-3.5" />
+                                    {activeFilterCount > 0 && (
+                                        <span className="absolute -right-1 -top-1 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-none text-primary-foreground tabular-nums">
+                                            {activeFilterCount}
+                                        </span>
+                                    )}
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                                align="end"
+                                className="flex w-auto max-w-[calc(100vw-2rem)] flex-col gap-3 p-3"
+                            >
+                                <FilterControls
+                                    query={query}
+                                    onQuery={onQuery}
+                                    groupFilters={groupFilters}
+                                    onToggleGroup={onToggleGroup}
+                                    statusFilters={statusFilters}
+                                    onToggleStatus={onToggleStatus}
+                                />
+                            </PopoverContent>
+                        </Popover>
 
                         {scrollControls}
-                    </div>
+                    </>
                 )}
 
                 <Button
@@ -213,6 +217,86 @@ export function ModelsSectionHeader({
 
             {collapsed && total > 0 && <CollapsedGroupTiles groupPreviews={groupPreviews} />}
         </div>
+    );
+}
+
+/**
+ * The filter controls (search + type + status). Rendered inline in the header
+ * on desktop, and stacked inside a popover on mobile. Pass `searchRef` only to
+ * the instance that should own the "/" focus shortcut (the desktop one) to
+ * avoid a ref collision between the two instances.
+ */
+function FilterControls({
+    searchRef,
+    query,
+    onQuery,
+    groupFilters,
+    onToggleGroup,
+    statusFilters,
+    onToggleStatus,
+}: {
+    searchRef?: RefObject<HTMLInputElement>;
+    query: string;
+    onQuery: (q: string) => void;
+    groupFilters: Set<ModelGroup>;
+    onToggleGroup: (g: ModelGroup) => void;
+    statusFilters: Set<ModelHeat>;
+    onToggleStatus: (k: ModelHeat) => void;
+}) {
+    return (
+        <>
+            <div className="relative">
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+                <Input
+                    ref={searchRef}
+                    value={query}
+                    onChange={(e) => onQuery(e.target.value)}
+                    placeholder="search models…"
+                    aria-label="Search models"
+                    className="h-7 w-44 pl-7 pr-7 text-xs"
+                />
+                {query && (
+                    <button
+                        type="button"
+                        onClick={() => onQuery("")}
+                        aria-label="Clear search"
+                        className="absolute right-1.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    >
+                        <X className="h-3 w-3" />
+                    </button>
+                )}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">type</span>
+                <SegmentedGroup label="Filter by model type">
+                    {GROUPS.map((g) => (
+                        <FilterChip
+                            key={g}
+                            label={g}
+                            color={GROUP_COLOR[g]}
+                            active={groupFilters.has(g)}
+                            onClick={() => onToggleGroup(g)}
+                        />
+                    ))}
+                </SegmentedGroup>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">status</span>
+                <SegmentedGroup label="Filter by status">
+                    {FILTERABLE_HEAT.map((k) => (
+                        <FilterChip
+                            key={k}
+                            label={k}
+                            color={MODEL_STATUS[k].color}
+                            active={statusFilters.has(k)}
+                            onClick={() => onToggleStatus(k)}
+                        />
+                    ))}
+                </SegmentedGroup>
+            </div>
+        </>
     );
 }
 

--- a/workbench/_web/src/components/models/ModelsSectionHeader.tsx
+++ b/workbench/_web/src/components/models/ModelsSectionHeader.tsx
@@ -96,6 +96,21 @@ export function ModelsSectionHeader({
                             {filtered ? `${filteredTotal} of ${total}` : total}
                         </span>
                     )}
+                    <a
+                        href="https://ndif.us"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        title="Models are served through NDIF — visit ndif.us"
+                        className="group inline-flex items-center gap-1.5 self-center text-xs text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                        <span>served by</span>
+                        <img
+                            src="/images/NDIF.png"
+                            alt="NDIF"
+                            className="h-6 w-auto opacity-80 transition-opacity group-hover:opacity-100"
+                        />
+                    </a>
                 </div>
 
                 {collapsed && isLoading && (
@@ -190,7 +205,9 @@ export function ModelsSectionHeader({
                             </PopoverContent>
                         </Popover>
 
-                        {scrollControls}
+                        {/* Desktop only — on mobile the carousel is scrolled by
+                            touch, so the paging controls are redundant. */}
+                        <div className="hidden md:flex">{scrollControls}</div>
                     </>
                 )}
 

--- a/workbench/_web/src/components/models/ModelsSectionHeader.tsx
+++ b/workbench/_web/src/components/models/ModelsSectionHeader.tsx
@@ -39,6 +39,10 @@ interface ModelsSectionHeaderProps {
 
     groupFilters: Set<ModelGroup>;
     onToggleGroup: (g: ModelGroup) => void;
+
+    /** Carousel nav (progress + paging) rendered inline with the filters when
+     * the row overflows. Null when there's nothing to scroll. */
+    scrollControls?: React.ReactNode;
 }
 
 export function ModelsSectionHeader({
@@ -55,6 +59,7 @@ export function ModelsSectionHeader({
     onToggleStatus,
     groupFilters,
     onToggleGroup,
+    scrollControls,
 }: ModelsSectionHeaderProps) {
     const searchRef = useRef<HTMLInputElement>(null);
     const filtered = filteredTotal !== total;
@@ -180,6 +185,8 @@ export function ModelsSectionHeader({
                                 ))}
                             </SegmentedGroup>
                         </div>
+
+                        {scrollControls}
                     </div>
                 )}
 

--- a/workbench/_web/src/components/selectors/LaunchSelectors.tsx
+++ b/workbench/_web/src/components/selectors/LaunchSelectors.tsx
@@ -18,6 +18,7 @@ export type WorkspaceListItem = Awaited<ReturnType<typeof getWorkspaces>>[number
 /** The tool values the chart-creation flow understands. */
 export const TOOL_OPTIONS: PillPopoverOption[] = [
     { value: "Logit Lens", label: "Logit Lens", group: "Tools" },
+    { value: "J-Lens", label: "J-Lens", group: "Tools" },
     { value: "Activation Patching", label: "Activation Patching", group: "Tools" },
 ];
 

--- a/workbench/_web/src/components/selectors/LaunchSelectors.tsx
+++ b/workbench/_web/src/components/selectors/LaunchSelectors.tsx
@@ -15,10 +15,17 @@ import type { getWorkspaces } from "@/lib/queries/workspaceQueries";
 
 export type WorkspaceListItem = Awaited<ReturnType<typeof getWorkspaces>>[number];
 
+/** "New" badge marking a recently added tool in the picker. */
+const NewBadge = () => (
+    <span className="shrink-0 rounded-full bg-purple-500/15 px-1.5 py-0.5 text-xs font-medium leading-none text-purple-600 dark:text-purple-400">
+        New
+    </span>
+);
+
 /** The tool values the chart-creation flow understands. */
 export const TOOL_OPTIONS: PillPopoverOption[] = [
     { value: "Logit Lens", label: "Logit Lens", group: "Tools" },
-    { value: "J-Lens", label: "J-Lens", group: "Tools" },
+    { value: "J-Lens", label: "J-Lens", group: "Tools", trailing: <NewBadge /> },
     { value: "Activation Patching", label: "Activation Patching", group: "Tools" },
 ];
 

--- a/workbench/_web/src/hooks/useToolArea.ts
+++ b/workbench/_web/src/hooks/useToolArea.ts
@@ -6,6 +6,8 @@ import { queryKeys } from "@/lib/queryKeys";
 import { useWorkspace } from "@/stores/useWorkspace";
 import { useModelsQuery } from "@/lib/api/modelsApi";
 import { isModelRunnable } from "@/components/model-selector/status";
+import { isToolSupportedForModel } from "@/lib/toolSupport";
+import type { ToolType } from "@/types/charts";
 
 interface ConfigWithModel {
     id: string;
@@ -36,6 +38,11 @@ interface UseToolAreaResult<TConfig extends ConfigWithModel, TChart extends Char
      * the model has gone cold or left the catalog — the Controls should be
      * read-only in that case (the saved chart still renders via the Display). */
     modelRunnable: boolean;
+    /** Whether `effectiveModel` supports this chart's tool (some tools, e.g.
+     * j-lens, only work with a subset of models). True when the model is
+     * unknown/unavailable so read-only rendering is unaffected; only a known,
+     * in-catalog model that lacks the tool's capability makes this false. */
+    isModelSupported: boolean;
 }
 
 /**
@@ -103,10 +110,20 @@ export function useToolArea<
 
     const hasExistingData = !!typedChart?.data;
 
-    const modelRunnable = useMemo(
-        () => isModelRunnable(models?.find((m) => m.name === effectiveModel)),
+    const currentModel = useMemo(
+        () => models?.find((m) => m.name === effectiveModel),
         [models, effectiveModel],
     );
+
+    const modelRunnable = useMemo(() => isModelRunnable(currentModel), [currentModel]);
+
+    // A model that isn't in the live catalog (undefined) leaves this true so
+    // the saved chart keeps rendering read-only; only a known model missing the
+    // tool's capability trips it. Unrestricted tools are always supported.
+    const isModelSupported = useMemo(() => {
+        if (!typedConfig || !currentModel) return true;
+        return isToolSupportedForModel(typedConfig.type as ToolType, currentModel);
+    }, [typedConfig, currentModel]);
 
     return {
         config: typedConfig,
@@ -118,5 +135,6 @@ export function useToolArea<
         effectiveModel,
         hasExistingData,
         modelRunnable,
+        isModelSupported,
     };
 }

--- a/workbench/_web/src/lib/api/chartApi.ts
+++ b/workbench/_web/src/lib/api/chartApi.ts
@@ -4,6 +4,7 @@ import {
     setChartData,
     deleteChart,
     createLens2ChartPair,
+    createJLensChartPair,
     createPatchLensChartPair,
     createPatchChartPair,
     createActivationPatchingChartPair,
@@ -13,6 +14,7 @@ import {
 } from "@/lib/queries/chartQueries";
 import { LensConfigData } from "@/types/lens";
 import { Lens2ConfigData } from "@/types/lens2";
+import { JLensConfigData } from "@/types/jlens";
 import { PatchingConfig } from "@/types/patching";
 import { ActivationPatchingConfigData } from "@/types/activationPatching";
 import { useCapture } from "@/components/providers/CaptureProvider";
@@ -265,6 +267,32 @@ export const useCreateLens2ChartPair = () => {
             config?: Lens2ConfigData;
         }) => {
             return await createLens2ChartPair(workspaceId, config);
+        },
+        onSuccess: (_, { workspaceId }) => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.charts.sidebar(workspaceId) });
+        },
+    });
+};
+
+export const useCreateJLensChartPair = () => {
+    const queryClient = useQueryClient();
+
+    const defaultConfig: JLensConfigData = {
+        prompt: "",
+        model: "",
+        topk: 5,
+        includeEntropy: true,
+    };
+
+    return useMutation({
+        mutationFn: async ({
+            workspaceId,
+            config = defaultConfig,
+        }: {
+            workspaceId: string;
+            config?: JLensConfigData;
+        }) => {
+            return await createJLensChartPair(workspaceId, config);
         },
         onSuccess: (_, { workspaceId }) => {
             queryClient.invalidateQueries({ queryKey: queryKeys.charts.sidebar(workspaceId) });

--- a/workbench/_web/src/lib/api/jlensApi.ts
+++ b/workbench/_web/src/lib/api/jlensApi.ts
@@ -1,0 +1,96 @@
+/**
+ * J-Lens API - Jacobian lens visualization API (reuses the LogitLens data format)
+ */
+
+import config from "@/lib/config";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { setChartData } from "@/lib/queries/chartQueries";
+import { JLensConfigData, JLensData } from "@/types/jlens";
+import { queryKeys } from "../queryKeys";
+import { toast } from "sonner";
+import { startAndPoll } from "../startAndPoll";
+import { createUserHeadersAction } from "@/actions/auth";
+
+/**
+ * API request for j-lens endpoint
+ */
+interface JLensRequest {
+    completion: JLensConfigData;
+    chartId: string;
+}
+
+/**
+ * Fetch j-lens data from the backend
+ */
+const getJLens = async (lensRequest: JLensRequest): Promise<JLensData> => {
+    const headers = await createUserHeadersAction();
+
+    // Transform to backend request format
+    const request = {
+        model: lensRequest.completion.model,
+        prompt: lensRequest.completion.prompt,
+        topk: lensRequest.completion.topk ?? 5,
+        include_entropy: lensRequest.completion.includeEntropy ?? true,
+    };
+
+    return await startAndPoll<JLensData>(
+        config.endpoints.startJLens,
+        request,
+        config.endpoints.resultsJLens,
+        headers,
+    );
+};
+
+/**
+ * React Query mutation hook for j-lens visualization
+ */
+export const useJLens = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationKey: ["jlens"],
+        onMutate: async ({ lensRequest }: { lensRequest: JLensRequest; configId: string }) => {
+            const chartKey = queryKeys.charts.chart(lensRequest.chartId);
+            await queryClient.cancelQueries({ queryKey: chartKey });
+            const previousChart = queryClient.getQueryData(chartKey);
+            queryClient.setQueryData(chartKey, (old: unknown) => {
+                if (!old) return old;
+                return { ...(old as object), type: "jlens" };
+            });
+            return { previousChart, chartKey } as {
+                previousChart: unknown;
+                chartKey: ReturnType<typeof queryKeys.charts.chart>;
+            };
+        },
+        mutationFn: async ({ lensRequest }: { lensRequest: JLensRequest; configId: string }) => {
+            const response = await getJLens(lensRequest);
+            // Store the j-lens data as chart data (in LogitLens V2 format)
+            await setChartData(lensRequest.chartId, response, "jlens");
+            return response;
+        },
+        onError: (error, variables, context) => {
+            if (context?.previousChart) {
+                queryClient.setQueryData(context.chartKey, context.previousChart);
+            }
+            toast.error("Failed to compute j-lens visualization");
+        },
+        onSuccess: async (data, variables) => {
+            const chartKey = queryKeys.charts.chart(variables.lensRequest.chartId);
+            await queryClient.invalidateQueries({ queryKey: chartKey });
+
+            // Do NOT invalidate configByChart here. The lens run is always
+            // followed by `updateConfig` in the caller (JLensControls.handleSubmit
+            // and the auto-run effect), and useUpdateChartConfig owns that
+            // invalidation. Triggering it here races the in-flight config write
+            // and can cache the pre-write (stale) row.
+            const chart = queryClient.getQueryData(chartKey) as
+                | { workspaceId?: string }
+                | undefined;
+            if (chart?.workspaceId) {
+                queryClient.invalidateQueries({
+                    queryKey: queryKeys.charts.sidebar(chart.workspaceId),
+                });
+            }
+        },
+    });
+};

--- a/workbench/_web/src/lib/config.ts
+++ b/workbench/_web/src/lib/config.ts
@@ -16,6 +16,9 @@ const config = {
         startLens2: "/logit_lens/start",
         resultsLens2: (jobId: string) => `/logit_lens/results/${jobId}`,
 
+        startJLens: "/j_lens/start",
+        resultsJLens: (jobId: string) => `/j_lens/results/${jobId}`,
+
         startCausalMediation: "/causal_mediation/start",
         resultsCausalMediation: (jobId: string) => `/causal_mediation/results/${jobId}`,
 

--- a/workbench/_web/src/lib/configModelDiff.ts
+++ b/workbench/_web/src/lib/configModelDiff.ts
@@ -1,4 +1,5 @@
 import type { Lens2ConfigData } from "@/types/lens2";
+import type { JLensConfigData } from "@/types/jlens";
 import type { ActivationPatchingConfigData, SourcePosition } from "@/types/activationPatching";
 import type { Token } from "@/types/models";
 
@@ -80,6 +81,21 @@ export function lens2ConfigEqualsExceptModel(
     draft: Omit<Lens2ConfigData, "model"> | null | undefined,
 ): boolean {
     return configFieldsEqual(saved as Lens2ConfigData, draft as Lens2ConfigData, [
+        (c) => c.prompt ?? "",
+        (c) => c.topk ?? 5,
+        (c) => c.includeEntropy ?? true,
+    ]);
+}
+
+/**
+ * Compare a j-lens draft against its saved config, excluding model. Same knobs
+ * as lens2 (prompt/top-k/entropy).
+ */
+export function jlensConfigEqualsExceptModel(
+    saved: JLensConfigData | undefined | null,
+    draft: Omit<JLensConfigData, "model"> | null | undefined,
+): boolean {
+    return configFieldsEqual(saved as JLensConfigData, draft as JLensConfigData, [
         (c) => c.prompt ?? "",
         (c) => c.topk ?? 5,
         (c) => c.includeEntropy ?? true,

--- a/workbench/_web/src/lib/queries/chartQueries.ts
+++ b/workbench/_web/src/lib/queries/chartQueries.ts
@@ -5,6 +5,7 @@ import { db } from "@/db/client";
 import { charts, configs, chartConfigLinks, Chart, LensConfig, Config } from "@/db/schema";
 import { LensConfigData } from "@/types/lens";
 import { Lens2ConfigData } from "@/types/lens2";
+import { JLensConfigData } from "@/types/jlens";
 import { PatchingConfig } from "@/types/patching";
 import { ActivationPatchingConfigData } from "@/types/activationPatching";
 import { PatchLensChartData } from "@/types/patchLens";
@@ -59,6 +60,7 @@ export const getConfigForChart = async (chartId: string): Promise<Config | null>
 type ConfigPayload =
     | { type: "lens"; data: LensConfigData }
     | { type: "lens2"; data: Lens2ConfigData }
+    | { type: "jlens"; data: JLensConfigData }
     | { type: "patch"; data: PatchingConfig }
     | { type: "activation-patching"; data: ActivationPatchingConfigData }
     | { type: "patch-lens"; data: Record<string, never> };
@@ -104,6 +106,9 @@ export const createLensChartPair = async (
 
 export const createLens2ChartPair = async (workspaceId: string, defaultConfig: Lens2ConfigData) =>
     createChartConfigPair(workspaceId, { type: "lens2", data: defaultConfig });
+
+export const createJLensChartPair = async (workspaceId: string, defaultConfig: JLensConfigData) =>
+    createChartConfigPair(workspaceId, { type: "jlens", data: defaultConfig });
 
 export const createPatchLensChartPair = async (
     workspaceId: string,

--- a/workbench/_web/src/lib/startAndPoll.ts
+++ b/workbench/_web/src/lib/startAndPoll.ts
@@ -1,7 +1,7 @@
 import config from "./config";
 import { useWorkspace } from "@/stores/useWorkspace";
 
-const POLL_TIMEOUT_MS = 60000;
+const POLL_TIMEOUT_MS = 300000;
 const POLL_INTERVAL_MS = 1000;
 
 async function awaitNDIFJob(jobId: string): Promise<void> {

--- a/workbench/_web/src/lib/toolSupport.ts
+++ b/workbench/_web/src/lib/toolSupport.ts
@@ -1,0 +1,80 @@
+/**
+ * Tool ↔ model support.
+ *
+ * Some tools only work with a subset of models (e.g. j-lens needs a Jacobian
+ * lens checkpoint, exposed per-model as `model.has_jacobian`), while others
+ * support every model. This is the single source of truth for "does tool T
+ * support model M?" so no UI surface hardcodes a per-tool capability check.
+ *
+ * The backend describes model *capabilities* (real properties like
+ * `has_jacobian`); here we map each *tool* to the capability it requires.
+ * Adding a future restricted tool is one entry below (plus, if needed, one new
+ * backend model flag) — every picker and run-gate keeps working unchanged.
+ */
+
+import type { Model } from "@/types/models";
+import type { ToolType } from "@/types/charts";
+
+type ToolSupport =
+    | { supportsAll: true }
+    | {
+          supportsAll: false;
+          /** Whether a specific model supports this tool. */
+          isSupported: (model: Model) => boolean;
+          /** Shown in tooltips / the tool's unsupported banner. */
+          unsupportedReason: string;
+      };
+
+const TOOL_SUPPORT: Record<ToolType, ToolSupport> = {
+    lens: { supportsAll: true },
+    lens2: { supportsAll: true },
+    "activation-patching": { supportsAll: true },
+    "patch-lens": { supportsAll: true },
+    patch: { supportsAll: true },
+    jlens: {
+        supportsAll: false,
+        // `has_jacobian` is optional; a missing value means the backend couldn't
+        // determine availability — fail closed so we never launch a run that
+        // will error on NDIF, but the UI still explains why (unsupportedReason).
+        isSupported: (model) => model.has_jacobian === true,
+        unsupportedReason: "No J-Lens (Jacobian lens) is available for this model.",
+    },
+};
+
+/** Landing page / launch dialog tool *display names* → the internal ToolType. */
+export const TOOL_DISPLAY_TO_TYPE: Record<string, ToolType> = {
+    "Logit Lens": "lens2",
+    "J-Lens": "jlens",
+    "Activation Patching": "activation-patching",
+};
+
+/** Whether a tool only supports a subset of models (vs. every model). */
+export function isToolModelRestricted(tool: ToolType): boolean {
+    return !TOOL_SUPPORT[tool].supportsAll;
+}
+
+/** Whether `model` supports `tool`. Unrestricted tools support every model. */
+export function isToolSupportedForModel(tool: ToolType, model: Model): boolean {
+    const rule = TOOL_SUPPORT[tool];
+    return rule.supportsAll || rule.isSupported(model);
+}
+
+/** Filter `models` to those that support `tool`. */
+export function supportedModelsFor(tool: ToolType, models: Model[]): Model[] {
+    if (!isToolModelRestricted(tool)) return models;
+    return models.filter((m) => isToolSupportedForModel(tool, m));
+}
+
+/**
+ * Human-readable reason a tool is unavailable for unsupported models, or null
+ * for tools that support every model.
+ */
+export function unsupportedReasonFor(tool: ToolType): string | null {
+    const rule = TOOL_SUPPORT[tool];
+    return rule.supportsAll ? null : rule.unsupportedReason;
+}
+
+/** Resolve a tool *display name* (from the landing/launch pickers) to a ToolType. */
+export function toolTypeFromDisplay(display: string): ToolType | null {
+    return TOOL_DISPLAY_TO_TYPE[display] ?? null;
+}

--- a/workbench/_web/src/types/charts.ts
+++ b/workbench/_web/src/types/charts.ts
@@ -81,7 +81,13 @@ export type ConfigData =
     | ActivationPatchingConfigData
     | Record<string, never>; // patch-lens stores no config payload
 
-export type ChartType = "line" | "heatmap" | "lens2" | "jlens" | "activation-patching" | "patch-lens";
+export type ChartType =
+    | "line"
+    | "heatmap"
+    | "lens2"
+    | "jlens"
+    | "activation-patching"
+    | "patch-lens";
 export type ToolType = "lens" | "lens2" | "jlens" | "patch" | "activation-patching" | "patch-lens";
 
 export type ChartMetadata = {

--- a/workbench/_web/src/types/charts.ts
+++ b/workbench/_web/src/types/charts.ts
@@ -1,5 +1,6 @@
 import { LensConfigData } from "./lens";
 import { Lens2ConfigData, Lens2Data } from "./lens2";
+import { JLensConfigData, JLensData } from "./jlens";
 import { PatchLensChartData } from "./patchLens";
 import { PatchingConfig } from "./patching";
 import { ActivationPatchingConfigData, ActivationPatchingData } from "./activationPatching";
@@ -68,18 +69,20 @@ export type ChartData =
     | Line[]
     | HeatmapRow[]
     | Lens2Data
+    | JLensData
     | ActivationPatchingData
     | PatchLensChartData;
 export type ChartView = HeatmapViewData | LineViewData;
 export type ConfigData =
     | LensConfigData
     | Lens2ConfigData
+    | JLensConfigData
     | PatchingConfig
     | ActivationPatchingConfigData
     | Record<string, never>; // patch-lens stores no config payload
 
-export type ChartType = "line" | "heatmap" | "lens2" | "activation-patching" | "patch-lens";
-export type ToolType = "lens" | "lens2" | "patch" | "activation-patching" | "patch-lens";
+export type ChartType = "line" | "heatmap" | "lens2" | "jlens" | "activation-patching" | "patch-lens";
+export type ToolType = "lens" | "lens2" | "jlens" | "patch" | "activation-patching" | "patch-lens";
 
 export type ChartMetadata = {
     id: string;

--- a/workbench/_web/src/types/jlens.ts
+++ b/workbench/_web/src/types/jlens.ts
@@ -1,0 +1,30 @@
+/**
+ * J-Lens Types
+ *
+ * The Jacobian lens (j-lens) reuses the logit-lens data format and widget, so
+ * its data and UI-state types are re-exported from nnsightful's LogitLens types.
+ * API-specific config types remain local.
+ */
+
+import type { LogitLensData, LogitLensUIState } from "nnsightful";
+
+export type JLensData = LogitLensData;
+export type JLensUIState = LogitLensUIState;
+
+/**
+ * J-Lens metadata
+ */
+export type JLensMeta = LogitLensData["meta"];
+
+/**
+ * J-Lens configuration data (mirrors Lens2 — same prompt/top-k/entropy knobs)
+ */
+export interface JLensConfigData {
+    model: string;
+    prompt: string;
+    topk?: number; // Number of top-k predictions per cell (default: 5)
+    includeEntropy?: boolean; // Whether to include entropy data (default: true)
+    // Persisted heatmap UI state (pinned trajectories, selection, layer
+    // window, appearance) so the visualization restores across reloads.
+    uiState?: LogitLensUIState;
+}

--- a/workbench/_web/src/types/models.ts
+++ b/workbench/_web/src/types/models.ts
@@ -38,4 +38,7 @@ export interface Model {
     allowed: boolean;
     /** Optional warmth/availability hint from NDIF. Falls back to `allowed`/`gated`. */
     status?: ModelStatus;
+    /** Whether a Jacobian lens checkpoint exists for this model, i.e. whether
+     * the j-lens tool can run against it. Stamped by the backend /models route. */
+    has_jacobian?: boolean;
 }


### PR DESCRIPTION
## Summary

Adds **J-Lens** (Jacobian lens) as a first-class interpretability tool alongside Logit Lens, and introduces a general **per-model tool-support** layer so tools that only work with a subset of models surface that clearly in the UI. J-Lens reuses the logit-lens data shape and widget, and only runs on models that have a Jacobian-lens checkpoint (exposed per-model as `has_jacobian`).

> **Depends on nnsightful:** the `j_lens` tool and its `get_available_lenses()` / `get_lens_config()` / `load_jacobians()` API live in the `nnsightful` library. That side must be released and the dependency bumped for this to work end-to-end. A related heatmap-tooltip fix (first-click tooltip dismissed on mouse-move) also lives in nnsightful's `LogitLensWidget.tsx` and is tracked separately.

## What's included

### J-Lens tool (end to end)
- **Backend:** `_api/routes/j_lens.py` (`/j_lens/start` + `/results/{job_id}`), registered and mounted at `/j_lens`. Thin shim over `nnsightful.tools.j_lens`, mirroring `logit_lens.py`.
- **Frontend:** `types/jlens.ts`; `"jlens"` added to `ChartType`/`ToolType`/`ChartData`/`ConfigData`; endpoint paths in `config.ts`; `lib/api/jlensApi.ts` (`useJLens`); `createJLensChartPair` + `useCreateJLensChartPair`; the `j-lens/[chartId]` route with `JLensArea` / `JLensControls` / `JLensDisplay` (renders the shared `LogitLensWidget`); and full sidebar/navigation wiring (`ChartCardsSidebar`, `ChartCard`, workspace `page.tsx`).
- **Icon:** `JLensIcon` (a "J" + magnifying glass, Lucide-style) used in the sidebar, chart card, and mobile header.
- **Entry points:** J-Lens is selectable from the landing page and the model launch dialog (added to the shared `TOOL_OPTIONS`); `AutoWorkspaceCreator` creates a j-lens chart and routes to `/j-lens/`.

### Per-model tool support
- **Capability metadata:** `GET /models` stamps `has_jacobian` on each model via `j_lens.get_available_lenses()` (fail-open if the HF lookup errors); `has_jacobian` added to the `Model` type.
- **Single source of truth:** `lib/toolSupport.ts` — a `TOOL_SUPPORT` registry where each tool is either `supportsAll` (every model) or a predicate + reason. Tools that support all models are unaffected; adding a future restricted tool is one entry.
- **In-chart state:** `useToolArea` returns `isModelSupported`; the J-Lens Area/Controls/Display grey out and show an "unsupported model — pick one with a lens" banner when the active model has no lens (no auto-switch).
- **Model pickers:** `ModelPopover` disables + tooltips unsupported models, skips them in keyboard nav, and **sorts them to the bottom** of each group. Wired into the workspace header (`ModelControl`, tool derived from the route), the landing page picker, and the launch dialog (which blocks its submit + warns when the fixed model doesn't support the chosen tool).
- **Model display:** in the workspace model grid, lens-less models sort to the bottom of the cold tier.

### J-Lens capability sticker (prototype)
- `JLensStickerBadge` — a "J Lens" starburst rendered on model cards whose model has a Jacobian lens. Deliberately loud; included for evaluation and easy to revert.

### Misc
- Fix: lens tool routes now forward `topk`.
- Raise the NDIF poll timeout 60s → 5min for longer-running lens jobs.

## Testing
- `tsc --noEmit` and ESLint pass on all touched frontend files (only pre-existing `setDraftModel` warnings remain, shared with `Lens2Controls`).
- Backend `/models` verified to return `has_jacobian` per model; `/j_lens` routes mounted and importing cleanly.
- Manually exercised against a local instance (frontend :3000 / backend :8000) with remote NDIF.

## Notes for reviewers
- This branch is currently behind `main`; it may need a rebase/merge before merging.
- The sticker (`JLensStickerBadge`) is intentionally off the app's usual restrained design language — flag if you'd prefer the more product-native icon/chip variant instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added J-Lens analysis with prompt, top-k, and optional entropy settings.
  * Added responsive J-Lens charts with saved configurations, visualizations, and editable titles.
  * Added one-click J-Lens launch from the landing page and workbench.
  * Added J-Lens badges and model compatibility indicators.
* **Bug Fixes**
  * Prevented unsupported models from being selected for restricted tools.
  * Increased analysis polling time for longer-running jobs.
* **Improvements**
  * Enhanced model browsing with unified carousels, filters, navigation, and empty states.
  * Added reference links to tool panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->