### PR TITLE
Guided tutorial: don't let a restored patch erase the step's spotlights

### DIFF
--- a/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/tutorial/TutorialActivityPanel.tsx
+++ b/workbench/_web/src/app/workbench/[workspaceId]/patch-lens/[chartId]/components/tutorial/TutorialActivityPanel.tsx
@@ -168,6 +168,16 @@ export function TutorialActivityPanel({
     // step carrying the whole point of the tool, participants performed the
     // intervention successfully and then could not find its result — the panel
     // now says what changed (below) and rings the cell it changed in.
+    //
+    // The result cell is ADDED to the step's own spotlights, never substituted for
+    // them. `patchToken` is not evidence that a result is on screen: a patch
+    // restored from an earlier session is re-filed on arrival at this step
+    // (PatchLensDisplay's "restored patch" effect) even when no result grid is
+    // rendered. Replacing here meant that token silently deleted the two cells the
+    // step's task names — leaving the drag it asks for pointed at nothing, and
+    // (because a spotlight is also what forces a downsampled layer to render) the
+    // patch layer missing from the grid entirely. Lighting both is safe: an
+    // unrendered result grid resolves to no cell, so the extra target is inert.
     useEffect(() => {
         // Nothing is spotlit while the tutorial is off screen: these effects sit
         // above the `active` guard (hooks can't be conditional), so the invariant
@@ -175,9 +185,12 @@ export function TutorialActivityPanel({
         if (!store.active || !isPatchUnit || patchToken == null) return;
         if (spotlitPatch.current === patchToken) return;
         spotlitPatch.current = patchToken;
-        onSpotlight?.({ grid: "result", layer: "last", position: "last" });
+        onSpotlight?.([
+            ...(unitSpotlights ?? []),
+            { grid: "result", layer: "last", position: "last" },
+        ]);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [store.active, isPatchUnit, patchToken]);
+    }, [store.active, isPatchUnit, patchToken, unitSpotlights]);
 
     // Back to the top of the step on arrival. The steps are long enough to scroll,
     // and the container keeps its offset across a unit change — so advancing from


### PR DESCRIPTION
## The bug

On the patch step (`u4-patching`) the guiding cell highlight didn't show up. Reported symptom: on an 80-layer model the heatmap showed layer columns `[0, 40, 79]` with nothing lit, so the step's "drag this ringed cell onto that one" pointed at nothing.

It looked like a layer-stepping problem, but that was downstream. Two effects in `TutorialActivityPanel` both write the spotlight, and the second **replaced** the first:

1. The unit's own cells — `source@L20/P5 + target@L20/P5`.
2. A lone `{grid: "result", layer: "last", position: "last"}`, written whenever `patchToken != null`.

`patchToken` is not evidence that a result is on screen. `PatchLensDisplay` deliberately re-files a patch **restored from an earlier session** the moment the participant arrives at the patch step, even when no result grid is rendered. That token then deleted the two cells the step's task names and rang a grid that didn't exist.

Because a spotlight is also what forces a downsampled layer to render, erasing it removed layer 20 from the grid entirely — which is what made this read as a layer-stepping bug.

## The fix

Add the result cell to the step's spotlights instead of substituting for them. An unrendered result grid resolves to no cell, so the extra target is inert; once a result is on screen it's lit alongside the drag pair.

Trade-off: after a real patch there are now three rings rather than one. Keeping the step's guidance alive in every state seemed clearly better than going dark. The more precise alternative — threading "a result is actually rendered" from `PatchLensDisplay` into the panel and gating on that — is more invasive and wasn't needed to fix the failure.

## Verification

The real app path needs the 70B model via NDIF plus a workshop row, so this was verified against the real widget (`edulogitlens` `fa59004`) in a throwaway harness mirroring the page's import structure, with synthetic 80-layer data at a width forcing `layerStep=40`, driven by Chromium:

| mode | columns | rings |
|---|---|---|
| unit spotlights only | `0,20,40,79` | 2 |
| replace (before) | `0,40,79` | **0** |
| additive (after) | `0,20,40,79` | 2 |

The middle row reproduces the reported DOM reading exactly. Harness was deleted; the diff is one file.

## Gates

- `tsc --noEmit`: clean in the changed file (34 total errors, identical to baseline)
- `bun run lint`: identical to baseline (60 problems, none in the changed file)
- `prettier --check`: clean
- Tests: `183 pass / 1 fail` — the failure is in `useProlificTutorial.test.ts` and reproduces identically on a stashed clean tree, so it is pre-existing, not a regression
- `next build` deliberately not run (clobbers a running dev server's `.next`)

## How to verify on the preview

The preview image bakes `NEXT_PUBLIC_LOCAL_DB=true`, so it runs the in-code seed (10 units) rather than a Supabase tutorial — `u4-patching` is **step 8 of 10** there and carries the same `PATCH_DRAG` `L20` spotlights, so the code path is identical.

A fresh workspace won't reproduce the bug, since it needs `patchToken` set with no result grid:

1. Land on step 8 → rings on both `L20` cells.
2. Perform the patch → 3 rings (was 1: result only).
3. **Reload, or navigate away and back to step 8** → the regression case. Before: 0 rings, layer 20 absent. After: `L20` rings restored.

Step 3 is what was broken.

## Not addressed

`layer: 20` remains hard-coded in tutorial content and assumes a model with ≥21 layers; on a smaller model the spotlight snaps to the last layer. Confirmed out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patch-result spotlighting now preserves existing highlighted areas while also highlighting the final result cell.
  * Spotlight updates now stay synchronized when the highlighted patch unit changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->